### PR TITLE
docs: reframe limitations as v0.1 scope, not permanent

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ AST parsing avoids false positives from comments, migration files, and unrelated
 
 ## Limitations
 
-String-based ORM calls are not detected. Patterns like `.values('email')`, `.defer('email')`, or `Q(email=...)` use the column name as a string argument, which is structurally different from a direct attribute access. colref will not report these as references.
+v0.1 detects attribute-access references only (e.g. `user.email`). String-based ORM calls like `.values('email')`, `.defer('email')`, or `Q(email=...)` pass the column name as a string argument and are not yet covered. Support for these patterns will be added in a future version, as it requires per-ORM knowledge of which methods accept column names as strings.
 
 If colref reports no references, treat it as "none found in attribute-access form" — not as a guarantee the column is unused.
 


### PR DESCRIPTION
## Summary

- Changed "string-based ORM calls are not detected" to "not yet covered in v0.1, planned for a future version"
- Clarified that this is a scope decision, not a tree-sitter limitation — per-ORM knowledge of which methods accept column names as strings is required

## Test plan

- [ ] Review README visually