### PR TITLE
feat: initialize Go module and project structure

### DIFF
--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "colref",
+	Short: "Check whether a DB column is still referenced before you delete it",
+}
+
+var (
+	flagModel      string
+	flagField      string
+	flagModelsFile string
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check [path]",
+	Short: "Scan a codebase for references to a model field",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := "."
+		if len(args) == 1 {
+			dir = args[0]
+		}
+		fmt.Printf("check: model=%s field=%s dir=%s\n", flagModel, flagField, dir)
+		return nil
+	},
+}
+
+func init() {
+	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
+	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
+	checkCmd.Flags().StringVar(&flagModelsFile, "models-file", "", "Path to models.py (auto-detected if omitted)")
+	_ = checkCmd.MarkFlagRequired("model")
+	_ = checkCmd.MarkFlagRequired("field")
+
+	rootCmd.AddCommand(checkCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/shinagawa-web/colref
+
+go 1.25.5
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Closes #3

## Summary

- `go mod init github.com/shinagawa-web/colref`
- Add cobra for CLI subcommand handling
- Lay out `cmd/colref/` and `internal/parser/`, `internal/scanner/`
- Wire up `colref check --model --field [path]` with a placeholder `RunE`

## Test plan

- [x] `go build ./cmd/colref/` succeeds
- [x] `colref check --model User --field email` prints expected output