### PR TITLE
feat: parse Django models.py and extract field names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/parser/models.go
+++ b/internal/parser/models.go
@@ -1,0 +1,131 @@
+package parser
+
+import (
+	"context"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/python"
+)
+
+type Field struct {
+	Model string
+	Name  string
+}
+
+func ParseModels(src []byte) ([]Field, error) {
+	p := sitter.NewParser()
+	p.SetLanguage(python.GetLanguage())
+
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		return nil, err
+	}
+
+	var fields []Field
+	root := tree.RootNode()
+
+	for i := 0; i < int(root.ChildCount()); i++ {
+		node := root.Child(i)
+		if node.Type() != "class_definition" {
+			continue
+		}
+		if !isModelClass(node, src) {
+			continue
+		}
+		className := node.ChildByFieldName("name").Content(src)
+		for _, name := range extractFields(node, src) {
+			fields = append(fields, Field{Model: className, Name: name})
+		}
+	}
+
+	return fields, nil
+}
+
+// isModelClass returns true when a class inherits from a name ending in "Model".
+// This covers models.Model, AbstractModel, TimeStampedModel, etc.
+func isModelClass(node *sitter.Node, src []byte) bool {
+	superclasses := node.ChildByFieldName("superclasses")
+	if superclasses == nil {
+		return false
+	}
+	for i := 0; i < int(superclasses.ChildCount()); i++ {
+		child := superclasses.Child(i)
+		var ident string
+		switch child.Type() {
+		case "identifier":
+			ident = child.Content(src)
+		case "attribute":
+			attr := child.ChildByFieldName("attribute")
+			if attr != nil {
+				ident = attr.Content(src)
+			}
+		}
+		if strings.HasSuffix(ident, "Model") {
+			return true
+		}
+	}
+	return false
+}
+
+// extractFields returns the names of Django field assignments in a class body.
+// It matches assignments whose right-hand side references something ending in "Field"
+// or starts with "models." — the heuristic that covers all built-in Django fields
+// and most third-party ones.
+func extractFields(classNode *sitter.Node, src []byte) []string {
+	body := classNode.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+
+	var names []string
+	for i := 0; i < int(body.ChildCount()); i++ {
+		stmt := body.Child(i)
+		if stmt.Type() != "expression_statement" {
+			continue
+		}
+		assign := stmt.Child(0)
+		if assign == nil || assign.Type() != "assignment" {
+			continue
+		}
+		left := assign.ChildByFieldName("left")
+		right := assign.ChildByFieldName("right")
+		if left == nil || left.Type() != "identifier" {
+			continue
+		}
+		if isDjangoField(right, src) {
+			names = append(names, left.Content(src))
+		}
+	}
+	return names
+}
+
+func isDjangoField(node *sitter.Node, src []byte) bool {
+	if node == nil {
+		return false
+	}
+	// Unwrap call expressions to inspect the function being called.
+	if node.Type() == "call" {
+		fn := node.ChildByFieldName("function")
+		return isDjangoField(fn, src)
+	}
+	// attribute access: models.CharField, models.ForeignKey, etc.
+	// Anything under models.* is a Django field.
+	// For third-party fields not under models., fall back to the "Field" suffix.
+	if node.Type() == "attribute" {
+		obj := node.ChildByFieldName("object")
+		if obj != nil && obj.Content(src) == "models" {
+			return true
+		}
+		attr := node.ChildByFieldName("attribute")
+		if attr != nil && strings.HasSuffix(attr.Content(src), "Field") {
+			return true
+		}
+		return false
+	}
+	// bare identifier: CharField (when imported directly)
+	if node.Type() == "identifier" {
+		return strings.HasSuffix(node.Content(src), "Field")
+	}
+	return false
+}

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -1,0 +1,90 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseModels(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField(max_length=254)
+    name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "users"
+
+    def __str__(self):
+        return self.email
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+
+class NotAModel:
+    value = models.CharField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []Field{
+		{Model: "User", Name: "email"},
+		{Model: "User", Name: "name"},
+		{Model: "User", Name: "created_at"},
+		{Model: "Post", Name: "title"},
+		{Model: "Post", Name: "body"},
+		{Model: "Post", Name: "author"},
+	}
+
+	if len(fields) != len(want) {
+		t.Fatalf("got %d fields, want %d\n got: %v", len(fields), len(want), fields)
+	}
+	for i, f := range fields {
+		if f != want[i] {
+			t.Errorf("fields[%d] = %v, want %v", i, f, want[i])
+		}
+	}
+}
+
+func TestParseModels_AbstractBase(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+class Article(TimestampedModel):
+    title = models.CharField(max_length=200)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fields) == 0 {
+		t.Fatal("expected fields, got none")
+	}
+
+	// TimestampedModel ends in "Model" → included
+	// Article inherits TimestampedModel which ends in "Model" → included
+	models := map[string]bool{}
+	for _, f := range fields {
+		models[f.Model] = true
+	}
+	if !models["TimestampedModel"] {
+		t.Error("expected TimestampedModel to be included")
+	}
+	if !models["Article"] {
+		t.Error("expected Article to be included")
+	}
+}


### PR DESCRIPTION
Closes #4

## Summary

- Add `internal/parser` package with `ParseModels(src []byte) ([]Field, error)`
- Use tree-sitter (go-tree-sitter + Python grammar) to walk the AST
- Detect model classes by checking if any superclass name ends in `Model` (covers `models.Model`, `AbstractModel`, `TimestampedModel`, etc.)
- Extract field assignments where the right-hand side is a call to `models.*` or any identifier/attribute ending in `Field`
- `ForeignKey`, `ManyToManyField`, `OneToOneField` and other relation types are handled

## Test plan

- [x] `go test ./internal/parser/` passes
- [x] `NotAModel` classes are excluded
- [x] Abstract base models and classes inheriting from them are included