### PR TITLE
feat: scan codebase for attribute-access references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ References found for User.email
 
 ### models.py auto-detection
 
-colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
+> **Planned — implemented in the CLI wiring phase.**
+
+colref will locate `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
 
 If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ colref scans your codebase with an AST parser, skips comments and string literal
 ## Usage
 
 ```
-colref check --model User --field email
+colref check --model User --field email [path]
 ```
+
+`path` is the directory to scan (default: current directory).
 
 Output:
 
@@ -36,6 +38,43 @@ References found for User.email
   accounts/views.py:88         obj.email
   notifications/tasks.py:12    instance.email
 ```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--model` | Model name to look up (required) |
+| `--field` | Field name to search for (required) |
+| `--models-file` | Path to a specific `models.py` (see below) |
+
+### models.py auto-detection
+
+colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
+
+If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
+
+```
+Error: model "User" found in multiple files:
+  accounts/models.py
+  legacy/models.py
+Use --models-file to specify which one.
+```
+
+Use `--models-file` to point to a specific file and resolve the ambiguity:
+
+```
+colref check --model User --field email --models-file accounts/models.py
+```
+
+### Skipped directories
+
+The following directories are never scanned:
+
+- `.git`, and any directory whose name starts with `.`
+- `__pycache__`
+- `venv`, `.venv`
+- `migrations`
+- `node_modules`
 
 ## Installation
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -37,7 +37,7 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if strings.HasPrefix(name, ".") || skipDirs[name] {
+			if path != dir && (strings.HasPrefix(name, ".") || skipDirs[name]) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -59,7 +59,10 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 			return err
 		}
 
-		rel, _ := filepath.Rel(dir, path)
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			rel = filepath.Clean(path)
+		}
 		walkNode(tree.RootNode(), src, fieldName, rel, &refs)
 		return nil
 	})

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/python"
+)
+
+type Reference struct {
+	File string
+	Line int
+	Text string
+}
+
+var skipDirs = map[string]bool{
+	"__pycache__":  true,
+	"venv":         true,
+	"migrations":   true,
+	"node_modules": true,
+}
+
+// Scan walks dir and returns every attribute-access node whose attribute name
+// equals fieldName, along with the total number of .py files examined.
+func Scan(dir, fieldName string) ([]Reference, int, error) {
+	lang := python.GetLanguage()
+	var refs []Reference
+	filesScanned := 0
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || skipDirs[name] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".py") {
+			return nil
+		}
+		filesScanned++
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		p := sitter.NewParser()
+		p.SetLanguage(lang)
+		tree, err := p.ParseCtx(context.Background(), nil, src)
+		if err != nil {
+			return err
+		}
+
+		rel, _ := filepath.Rel(dir, path)
+		walkNode(tree.RootNode(), src, fieldName, rel, &refs)
+		return nil
+	})
+
+	return refs, filesScanned, err
+}
+
+func walkNode(node *sitter.Node, src []byte, fieldName, file string, refs *[]Reference) {
+	if node.Type() == "attribute" {
+		attr := node.ChildByFieldName("attribute")
+		if attr != nil && attr.Content(src) == fieldName {
+			*refs = append(*refs, Reference{
+				File: file,
+				Line: int(node.StartPoint().Row) + 1,
+				Text: node.Content(src),
+			})
+			// The object subtree cannot itself end in the same attribute name
+			// unless it is a coincidental deeper match, so keep recursing to
+			// catch patterns like a.email.email (rare but valid).
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkNode(node.Child(i), src, fieldName, file, refs)
+	}
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -113,6 +113,31 @@ func TestScan_SkipMigrationsDir(t *testing.T) {
 	}
 }
 
+func TestScan_DotDirAsRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.email`)
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig)
+
+	refs, count, err := Scan(".", "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned when dir is \".\", got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d", len(refs))
+	}
+}
+
 func TestScan_MultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "a.py", `x = user.email`)

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,132 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScan_BasicMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+def get_email(user):
+    return user.email
+`)
+
+	refs, count, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "user.email" {
+		t.Errorf("want text %q, got %q", "user.email", refs[0].Text)
+	}
+	if refs[0].Line != 3 {
+		t.Errorf("want line 3, got %d", refs[0].Line)
+	}
+}
+
+func TestScan_NestedAttributeAccess(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `email = request.user.email`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "request.user.email" {
+		t.Errorf("want %q, got %q", "request.user.email", refs[0].Text)
+	}
+}
+
+func TestScan_CommentNotMatched(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `# user.email is used here`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from comment, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_StringNotMatched(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.values("email")`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from string literal, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_NonMatchingAttribute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.name`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs, got %d", len(refs))
+	}
+}
+
+func TestScan_SkipMigrationsDir(t *testing.T) {
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, migrationsDir, "0001_initial.py", `x = user.email`)
+
+	refs, count, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 files scanned (migrations skipped), got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from migrations dir, got %d", len(refs))
+	}
+}
+
+func TestScan_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.py", `x = user.email`)
+	writeFile(t, dir, "b.py", `y = obj.email`)
+	writeFile(t, dir, "c.py", `z = item.name`)
+
+	refs, count, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("want 3 files scanned, got %d", count)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs, got %d: %v", len(refs), refs)
+	}
+}


### PR DESCRIPTION
Closes #5

## Summary

- Add `internal/scanner` package with `Scan(dir, fieldName string) ([]Reference, int, error)`
- Walk all `.py` files under the target directory using `filepath.WalkDir`
- For each file, parse with tree-sitter (Python grammar) and recursively walk the AST
- Collect every `attribute` node whose `attribute` field matches `fieldName`
- Comments and string literals are automatically excluded — tree-sitter does not produce attribute nodes inside them
- Skip `.git`, hidden dirs, `__pycache__`, `venv`, `.venv`, `migrations`, `node_modules`
- Also document the `models.py` auto-detection spec (Option C: union + conflict error) and skipped directories in README

## Test plan

- [x] `go test ./internal/scanner/` passes
- [x] Basic attribute access `user.email` is matched
- [x] Nested access `request.user.email` is matched (outer node only)
- [x] Comments (`# user.email`) are not matched
- [x] String literals (`.values("email")`) are not matched
- [x] Non-matching attribute names are ignored
- [x] `migrations/` directory is skipped
- [x] Multiple files return refs from all of them