### PR TITLE
feat: CLI check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ colref locates `models.py` automatically by walking the target directory. All `m
 If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
 
 ```
-Error: model "User" found in multiple files:
+model "User" found in multiple files:
   accounts/models.py
   legacy/models.py
 Use --models-file to specify which one.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ References found for User.email
 
 ### models.py auto-detection
 
-> **Planned — implemented in the CLI wiring phase.**
-
-colref will locate `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
+colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
 
 If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
 

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -11,12 +11,6 @@ import (
 	"github.com/shinagawa-web/colref/internal/scanner"
 )
 
-var skipDirsCheck = map[string]bool{
-	"__pycache__":  true,
-	"venv":         true,
-	"migrations":   true,
-	"node_modules": true,
-}
 
 func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	// Determine which models.py files to parse.
@@ -67,7 +61,11 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	if files := modelToFiles[modelName]; len(files) > 1 {
 		lines := []string{fmt.Sprintf("model %q found in multiple files:", modelName)}
 		for _, f := range files {
-			lines = append(lines, "  "+f)
+			rel, err := filepath.Rel(dir, f)
+			if err != nil {
+				rel = filepath.Clean(f)
+			}
+			lines = append(lines, "  "+rel)
 		}
 		lines = append(lines, "Use --models-file to specify which one.")
 		return fmt.Errorf("%s", strings.Join(lines, "\n"))
@@ -135,7 +133,7 @@ func findModelsFiles(dir string) ([]string, error) {
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if path != dir && (strings.HasPrefix(name, ".") || skipDirsCheck[name]) {
+			if path != dir && (strings.HasPrefix(name, ".") || scanner.SkipDirs[name]) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shinagawa-web/colref/internal/parser"
+	"github.com/shinagawa-web/colref/internal/scanner"
+)
+
+var skipDirsCheck = map[string]bool{
+	"__pycache__":  true,
+	"venv":         true,
+	"migrations":   true,
+	"node_modules": true,
+}
+
+func runCheck(dir, modelName, fieldName, modelsFile string) error {
+	// Determine which models.py files to parse.
+	var modelsFiles []string
+	if modelsFile != "" {
+		modelsFiles = []string{modelsFile}
+	} else {
+		var err error
+		modelsFiles, err = findModelsFiles(dir)
+		if err != nil {
+			return err
+		}
+		if len(modelsFiles) == 0 {
+			return fmt.Errorf("no models.py found under %s", dir)
+		}
+	}
+
+	// Parse each file and index models → source files.
+	type parsedFile struct {
+		path   string
+		fields []parser.Field
+	}
+	var parsed []parsedFile
+	for _, f := range modelsFiles {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		fields, err := parser.ParseModels(src)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", f, err)
+		}
+		parsed = append(parsed, parsedFile{path: f, fields: fields})
+	}
+
+	modelToFiles := map[string][]string{}
+	for _, pf := range parsed {
+		seen := map[string]bool{}
+		for _, field := range pf.fields {
+			if !seen[field.Model] {
+				seen[field.Model] = true
+				modelToFiles[field.Model] = append(modelToFiles[field.Model], pf.path)
+			}
+		}
+	}
+
+	// Conflict: same model name in multiple files.
+	if files := modelToFiles[modelName]; len(files) > 1 {
+		lines := []string{fmt.Sprintf("model %q found in multiple files:", modelName)}
+		for _, f := range files {
+			lines = append(lines, "  "+f)
+		}
+		lines = append(lines, "Use --models-file to specify which one.")
+		return fmt.Errorf("%s", strings.Join(lines, "\n"))
+	}
+
+	var allFields []parser.Field
+	for _, pf := range parsed {
+		allFields = append(allFields, pf.fields...)
+	}
+
+	// Validate model exists.
+	fieldNames := fieldsForModel(allFields, modelName)
+	if len(fieldNames) == 0 {
+		known := knownModels(allFields)
+		if len(known) == 0 {
+			return fmt.Errorf("model %q not found (no models detected)", modelName)
+		}
+		return fmt.Errorf("model %q not found\nAvailable models: %s", modelName, strings.Join(known, ", "))
+	}
+
+	// Validate field exists.
+	if !containsField(fieldNames, fieldName) {
+		return fmt.Errorf("field %q not found in model %q\nAvailable fields: %s",
+			fieldName, modelName, strings.Join(fieldNames, ", "))
+	}
+
+	// Scan the codebase.
+	refs, count, err := scanner.Scan(dir, fieldName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Scanning %d files...\n\n", count)
+
+	if len(refs) == 0 {
+		fmt.Printf("No references found for %s.%s\n\n", modelName, fieldName)
+		fmt.Printf("  String-based ORM calls (e.g. .values(), .defer()) are not detected.\n")
+		fmt.Printf("  Verify manually before deleting.\n")
+		return nil
+	}
+
+	fmt.Printf("References found for %s.%s\n\n", modelName, fieldName)
+	printRefs(refs)
+	return nil
+}
+
+func printRefs(refs []scanner.Reference) {
+	maxWidth := 0
+	for _, r := range refs {
+		if w := len(fmt.Sprintf("%s:%d", r.File, r.Line)); w > maxWidth {
+			maxWidth = w
+		}
+	}
+	for _, r := range refs {
+		label := fmt.Sprintf("%s:%d", r.File, r.Line)
+		fmt.Printf("  %s%s%s\n", label, strings.Repeat(" ", maxWidth-len(label)+3), r.Text)
+	}
+}
+
+func findModelsFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != dir && (strings.HasPrefix(name, ".") || skipDirsCheck[name]) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Base(path) == "models.py" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+func fieldsForModel(fields []parser.Field, model string) []string {
+	var names []string
+	for _, f := range fields {
+		if f.Model == model {
+			names = append(names, f.Name)
+		}
+	}
+	return names
+}
+
+func knownModels(fields []parser.Field) []string {
+	seen := map[string]bool{}
+	var models []string
+	for _, f := range fields {
+		if !seen[f.Model] {
+			seen[f.Model] = true
+			models = append(models, f.Model)
+		}
+	}
+	return models
+}
+
+func containsField(fields []string, name string) bool {
+	for _, f := range fields {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	accounts := filepath.Join(dir, "accounts")
+	blog := filepath.Join(dir, "blog")
+	if err := os.MkdirAll(accounts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(blog, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(filepath.Join(accounts, "models.py"), `
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    name = models.CharField(max_length=100)
+`)
+	write(filepath.Join(blog, "models.py"), `
+from django.db import models
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+`)
+	write(filepath.Join(accounts, "views.py"), `
+def send(user):
+    return user.email
+`)
+	write(filepath.Join(blog, "views.py"), `
+def show(post):
+    return post.title
+`)
+	return dir
+}
+
+func TestRunCheck_RefsFound(t *testing.T) {
+	dir := setupFixture(t)
+	if err := runCheck(dir, "User", "email", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_NoRefs(t *testing.T) {
+	dir := setupFixture(t)
+	if err := runCheck(dir, "User", "name", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_UnknownModel(t *testing.T) {
+	dir := setupFixture(t)
+	err := runCheck(dir, "Invoice", "amount", "")
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "User") && !strings.Contains(err.Error(), "Post") {
+		t.Errorf("error should list available models, got: %v", err)
+	}
+}
+
+func TestRunCheck_UnknownField(t *testing.T) {
+	dir := setupFixture(t)
+	err := runCheck(dir, "User", "emial", "")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "email") {
+		t.Errorf("error should list available fields, got: %v", err)
+	}
+}
+
+func TestRunCheck_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	apps := []string{"app1", "app2"}
+	for _, app := range apps {
+		d := filepath.Join(dir, app)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := runCheck(dir, "User", "email", "")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "multiple files") {
+		t.Errorf("error should mention 'multiple files', got: %v", err)
+	}
+	// Conflict paths should be relative (not absolute).
+	if strings.Contains(err.Error(), dir) {
+		t.Errorf("conflict paths should be relative, got: %v", err)
+	}
+}
+
+func TestRunCheck_ModelsFile(t *testing.T) {
+	dir := setupFixture(t)
+	modelsFile := filepath.Join(dir, "accounts", "models.py")
+	if err := runCheck(dir, "User", "email", modelsFile); err != nil {
+		t.Fatalf("unexpected error with --models-file: %v", err)
+	}
+}
+
+func TestRunCheck_NoModelsFile(t *testing.T) {
+	dir := t.TempDir()
+	err := runCheck(dir, "User", "email", "")
+	if err == nil {
+		t.Fatal("expected error when no models.py found")
+	}
+	if !strings.Contains(err.Error(), "no models.py") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -15,9 +15,9 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:          "colref",
-	Short:        "Check whether a DB column is still referenced before you delete it",
-	SilenceUsage: true,
+	Use:           "colref",
+	Short:         "Check whether a DB column is still referenced before you delete it",
+	SilenceUsage:  true,
 	SilenceErrors: true,
 }
 

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -15,8 +15,10 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "colref",
-	Short: "Check whether a DB column is still referenced before you delete it",
+	Use:          "colref",
+	Short:        "Check whether a DB column is still referenced before you delete it",
+	SilenceUsage: true,
+	SilenceErrors: true,
 }
 
 var (
@@ -34,8 +36,7 @@ var checkCmd = &cobra.Command{
 		if len(args) == 1 {
 			dir = args[0]
 		}
-		fmt.Printf("check: model=%s field=%s dir=%s\n", flagModel, flagField, dir)
-		return nil
+		return runCheck(dir, flagModel, flagField, flagModelsFile)
 	},
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -17,7 +17,9 @@ type Reference struct {
 	Text string
 }
 
-var skipDirs = map[string]bool{
+// SkipDirs is the set of directory names that are never scanned.
+// Exported so CLI code that walks for models.py can apply the same rules.
+var SkipDirs = map[string]bool{
 	"__pycache__":  true,
 	"venv":         true,
 	"migrations":   true,
@@ -37,7 +39,7 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if path != dir && (strings.HasPrefix(name, ".") || skipDirs[name]) {
+			if path != dir && (strings.HasPrefix(name, ".") || SkipDirs[name]) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -65,11 +65,26 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 		if err != nil {
 			rel = filepath.Clean(path)
 		}
-		walkNode(tree.RootNode(), src, fieldName, rel, &refs)
+		var fileRefs []Reference
+		walkNode(tree.RootNode(), src, fieldName, rel, &fileRefs)
+		refs = append(refs, dedupeByLine(fileRefs)...)
 		return nil
 	})
 
 	return refs, filesScanned, err
+}
+
+// dedupeByLine keeps the first Reference seen for each line number.
+func dedupeByLine(refs []Reference) []Reference {
+	seen := map[int]bool{}
+	out := refs[:0:0]
+	for _, r := range refs {
+		if !seen[r.Line] {
+			seen[r.Line] = true
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 func walkNode(node *sitter.Node, src []byte, fieldName, file string, refs *[]Reference) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -138,6 +138,20 @@ func TestScan_DotDirAsRoot(t *testing.T) {
 	}
 }
 
+func TestScan_DuplicateOnSameLine(t *testing.T) {
+	dir := t.TempDir()
+	// self.email appears twice on the same line (lhs and rhs of assignment).
+	writeFile(t, dir, "models.py", `self.email = normalize(self.email)`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (deduped), got %d: %v", len(refs), refs)
+	}
+}
+
 func TestScan_MultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "a.py", `x = user.email`)


### PR DESCRIPTION
Closes #6

## Summary

- Add `cmd/colref/check.go` with `runCheck` that orchestrates the full flow
- Wire `RunE` in `main.go` to call `runCheck`

## Flow

1. **models.py 検出**: `--models-file` 指定があればそのファイルのみ、なければ対象ディレクトリを walk して全 `models.py` を収集（scanner と同じスキップルール適用）
2. **衝突検出**: `--model` が複数ファイルに存在する場合はエラー + `--models-file` 使用を案内
3. **バリデーション**: `--model` が存在しない場合は利用可能なモデル一覧を表示。`--field` が存在しない場合は利用可能なフィールド一覧を表示
4. **スキャン**: `scanner.Scan` を実行
5. **出力**: README のフォーマット通りに整形（`path:line` を最大幅で列揃え）

## Error handling

- Exit 0: 成功（refs あり・なし問わず）
- Exit 1: モデル/フィールド未検出、衝突、I/O エラー
- `SilenceErrors: true` + `SilenceUsage: true` で cobra の二重出力を抑制

## Test plan

- [x] `go build ./cmd/colref/` passes
- [x] 参照あり: 列揃えで正しく出力される
- [x] 参照なし: ORM 警告が表示される
- [x] 存在しないモデル: 利用可能なモデル一覧を表示してexit 1
- [x] タイポしたフィールド: 利用可能なフィールド一覧を表示してexit 1
- [x] comment 内の `user.email` はヒットしない
- [x] README の "Planned" 注記を削除