### PR TITLE
ci: lint with golangci-lint on PRs

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -1,0 +1,29 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: reviewdog/action-golangci-lint@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_flags: --config=./.golangci.yml
+          fail_level: error
+          reporter: github-pr-check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -11,7 +11,6 @@ import (
 	"github.com/shinagawa-web/colref/internal/scanner"
 )
 
-
 func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	// Determine which models.py files to parse.
 	var modelsFiles []string

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -124,7 +124,7 @@ func TestScan_DotDirAsRoot(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(orig)
+	t.Cleanup(func() { _ = os.Chdir(orig) })
 
 	refs, count, err := Scan(".", "email")
 	if err != nil {


### PR DESCRIPTION
Closes #12

## Summary

- Add `.github/workflows/golangci.yml` — runs on every PR targeting `main` via `reviewdog/action-golangci-lint`, reports findings as PR check annotations
- Add `.golangci.yml` (v2 format) — default linters + gofmt formatter
- Fix pre-existing lint issues surfaced by the new check:
  - `gofmt`: extra blank line in `check.go`
  - `errcheck`: `defer os.Chdir` in test → `t.Cleanup(func() { _ = os.Chdir(orig) })`