### PR TITLE
fix: add checkout step to release job

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/


### PR DESCRIPTION
The release job was missing `actions/checkout`, causing `gh release create` to fail with 'not a git repository'.