### PR TITLE
ci: auto-label PRs by conventional commit prefix

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,46 @@
+name: auto-label
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labelMap = [
+              { pattern: /^feat(\(.+\))?(!)?:/, label: 'enhancement' },
+              { pattern: /^fix(\(.+\))?(!)?:/,  label: 'bug' },
+              { pattern: /^docs(\(.+\))?(!)?:/, label: 'documentation' },
+              { pattern: /^chore(\(.+\))?(!)?:/, label: 'chore' },
+              { pattern: /^refactor(\(.+\))?(!)?:/, label: 'refactor' },
+              { pattern: /^(deps|dependencies)(\(.+\))?(!)?:/, label: 'dependencies' },
+              { pattern: /^ci(\(.+\))?(!)?:/, label: 'ci' },
+            ];
+
+            const labels = labelMap
+              .filter(({ pattern }) => pattern.test(title))
+              .map(({ label }) => label);
+
+            if (context.payload.pull_request.title.includes('!:') ||
+                /\(.+\)!:/.test(title)) {
+              labels.push('breaking-change');
+            }
+
+            if (labels.length === 0) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels,
+            });

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,12 +1,13 @@
 name: auto-label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label:
@@ -17,30 +18,84 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
+
             const labelMap = [
-              { pattern: /^feat(\(.+\))?(!)?:/, label: 'enhancement' },
-              { pattern: /^fix(\(.+\))?(!)?:/,  label: 'bug' },
-              { pattern: /^docs(\(.+\))?(!)?:/, label: 'documentation' },
-              { pattern: /^chore(\(.+\))?(!)?:/, label: 'chore' },
-              { pattern: /^refactor(\(.+\))?(!)?:/, label: 'refactor' },
+              { pattern: /^feat(\(.+\))?(!)?:/,         label: 'enhancement' },
+              { pattern: /^fix(\(.+\))?(!)?:/,           label: 'bug' },
+              { pattern: /^docs(\(.+\))?(!)?:/,          label: 'documentation' },
+              { pattern: /^chore(\(.+\))?(!)?:/,         label: 'chore' },
+              { pattern: /^refactor(\(.+\))?(!)?:/,      label: 'refactor' },
               { pattern: /^(deps|dependencies)(\(.+\))?(!)?:/, label: 'dependencies' },
-              { pattern: /^ci(\(.+\))?(!)?:/, label: 'ci' },
+              { pattern: /^ci(\(.+\))?(!)?:/,            label: 'ci' },
             ];
+
+            const managedLabels = new Set([
+              ...labelMap.map(({ label }) => label),
+              'breaking-change',
+            ]);
 
             const labels = labelMap
               .filter(({ pattern }) => pattern.test(title))
               .map(({ label }) => label);
 
-            if (context.payload.pull_request.title.includes('!:') ||
-                /\(.+\)!:/.test(title)) {
+            if (/^(\w+)(\([^)]*\))?!:/.test(title)) {
               labels.push('breaking-change');
             }
 
-            if (labels.length === 0) return;
+            // Ensure all managed labels exist in the repo.
+            for (const label of managedLabels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'ededed',
+                });
+              }
+            }
 
-            await github.rest.issues.addLabels({
+            // Fetch current labels and sync: remove stale, add new.
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels,
             });
+
+            const currentManaged = currentLabels
+              .map(({ name }) => name)
+              .filter((name) => managedLabels.has(name));
+
+            for (const label of currentManaged.filter((l) => !labels.includes(l))) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: label,
+              });
+            }
+
+            const toAdd = labels.filter((l) => !currentManaged.includes(l));
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: toAdd,
+              });
+            }
+
+  check-label:
+    runs-on: ubuntu-latest
+    needs: label
+
+    steps:
+      - uses: agilepathway/label-checker@v1
+        with:
+          one_of: enhancement,bug,documentation,chore,refactor,dependencies,ci,breaking-change
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #14

## Summary

- Add `.github/workflows/auto-label.yml`
- Triggers on PR open, edit, and synchronize
- Maps conventional commit prefixes to labels via `actions/github-script`
- Create required labels on the repository

## Label mapping

| Prefix | Label |
|---|---|
| `feat:` | enhancement |
| `fix:` | bug |
| `docs:` | documentation |
| `chore:` | chore |
| `refactor:` | refactor |
| `deps:` / `dependencies:` | dependencies |
| `ci:` | ci |
| `type!:` or `type(scope)!:` | breaking-change |