### PR TITLE
ci: verify go install succeeds on Go-related changes

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -95,7 +95,7 @@ jobs:
     needs: label
 
     steps:
-      - uses: agilepathway/label-checker@v1
+      - uses: agilepathway/label-checker@v1.6.65
         with:
           one_of: enhancement,bug,documentation,chore,refactor,dependencies,ci,breaking-change
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "**.go"
+      - "**/*.go"
       - go.mod
       - go.sum
 
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Verify go install
         run: go install github.com/shinagawa-web/colref@latest

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -25,4 +25,4 @@ jobs:
           cache: true
 
       - name: Verify go install
-        run: go install github.com/shinagawa-web/colref@latest
+        run: go install ./cmd/colref

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,27 @@
+name: install
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Verify go install
+        run: go install github.com/shinagawa-web/colref@latest


### PR DESCRIPTION
## Summary
- Add `.github/workflows/install.yml`
- Triggers on push to `main` when `**.go`, `go.mod`, or `go.sum` are changed
- Sets up Go from `go.mod` and runs `go install github.com/shinagawa-web/colref@latest` to verify it succeeds

Closes #15

## Test plan
- [ ] Push a change to a Go source file or `go.mod` / `go.sum` to `main` and confirm the workflow triggers
- [ ] Confirm `go install` completes successfully