### PR TITLE
fix: pin label-checker action to v1.6.65

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -95,7 +95,7 @@ jobs:
     needs: label
 
     steps:
-      - uses: agilepathway/label-checker@v1
+      - uses: agilepathway/label-checker@v1.6.65
         with:
           one_of: enhancement,bug,documentation,chore,refactor,dependencies,ci,breaking-change
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `agilepathway/label-checker@v1` tag does not exist, causing `check-label` CI to fail on every PR
- Pin to `v1.6.65` (latest available tag)

## Note
CI will still fail on this PR itself (same root cause). Since branch protection is off, please merge via GitHub UI directly.