### PR TITLE
fix: also trigger install workflow on pull_request

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,6 +8,13 @@ on:
       - "**/*.go"
       - go.mod
       - go.sum
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - go.mod
+      - go.sum
 
 permissions:
   contents: read

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -16,7 +16,7 @@ func main() {
 
 var rootCmd = &cobra.Command{
 	Use:           "colref",
-	Short:         "Check whether a DB column is still referenced before you delete it.", // trigger CI
+	Short:         "Check whether a DB column is still referenced before you delete it",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -16,7 +16,7 @@ func main() {
 
 var rootCmd = &cobra.Command{
 	Use:           "colref",
-	Short:         "Check whether a DB column is still referenced before you delete it",
+	Short:         "Check whether a DB column is still referenced before you delete it.", // trigger CI
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to `install.yml` so broken `go install` is caught before merge, consistent with other workflows

## Test plan
- [ ] Open a PR that changes a Go file and confirm the install workflow runs