### PR TITLE
feat: introduce ORM abstraction layer

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/shinagawa-web/colref/internal/orm"
 	"github.com/shinagawa-web/colref/internal/parser"
 	"github.com/shinagawa-web/colref/internal/scanner"
 )
@@ -30,7 +31,7 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	// Parse each file and index models → source files.
 	type parsedFile struct {
 		path   string
-		fields []parser.Field
+		fields []orm.Field
 	}
 	var parsed []parsedFile
 	for _, f := range modelsFiles {
@@ -70,7 +71,7 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		return fmt.Errorf("%s", strings.Join(lines, "\n"))
 	}
 
-	var allFields []parser.Field
+	var allFields []orm.Field
 	for _, pf := range parsed {
 		allFields = append(allFields, pf.fields...)
 	}
@@ -111,7 +112,7 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	return nil
 }
 
-func printRefs(refs []scanner.Reference) {
+func printRefs(refs []orm.Reference) {
 	maxWidth := 0
 	for _, r := range refs {
 		if w := len(fmt.Sprintf("%s:%d", r.File, r.Line)); w > maxWidth {
@@ -145,7 +146,7 @@ func findModelsFiles(dir string) ([]string, error) {
 	return files, err
 }
 
-func fieldsForModel(fields []parser.Field, model string) []string {
+func fieldsForModel(fields []orm.Field, model string) []string {
 	var names []string
 	for _, f := range fields {
 		if f.Model == model {
@@ -155,7 +156,7 @@ func fieldsForModel(fields []parser.Field, model string) []string {
 	return names
 }
 
-func knownModels(fields []parser.Field) []string {
+func knownModels(fields []orm.Field) []string {
 	seen := map[string]bool{}
 	var models []string
 	for _, f := range fields {

--- a/internal/orm/orm.go
+++ b/internal/orm/orm.go
@@ -17,5 +17,6 @@ type SchemaParser interface {
 
 type ReferenceScanner interface {
 	Scan(dir, fieldName string) ([]Reference, int, error)
+	// SkipDirs returns a copy of the directory names that are never scanned.
 	SkipDirs() map[string]bool
 }

--- a/internal/orm/orm.go
+++ b/internal/orm/orm.go
@@ -1,0 +1,21 @@
+package orm
+
+type Field struct {
+	Model string
+	Name  string
+}
+
+type Reference struct {
+	File string
+	Line int
+	Text string
+}
+
+type SchemaParser interface {
+	ParseSchema(src []byte) ([]Field, error)
+}
+
+type ReferenceScanner interface {
+	Scan(dir, fieldName string) ([]Reference, int, error)
+	SkipDirs() map[string]bool
+}

--- a/internal/parser/models.go
+++ b/internal/parser/models.go
@@ -6,11 +6,19 @@ import (
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
+
+	"github.com/shinagawa-web/colref/internal/orm"
 )
 
-type Field struct {
-	Model string
-	Name  string
+// Field is a type alias for orm.Field for backward compatibility.
+type Field = orm.Field
+
+// DjangoParser implements orm.SchemaParser for Django/Python models.
+type DjangoParser struct{}
+
+// ParseSchema implements orm.SchemaParser.
+func (DjangoParser) ParseSchema(src []byte) ([]orm.Field, error) {
+	return ParseModels(src)
 }
 
 func ParseModels(src []byte) ([]Field, error) {

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -277,3 +277,19 @@ class MyModel(models.Model):
 		t.Error("expected 'config' (SomeUtils.VALUE) NOT to be found as a Django field")
 	}
 }
+
+func TestDjangoParser_ParseSchema(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+`)
+	fields, err := DjangoParser{}.ParseSchema(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("unexpected fields: %v", fields)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -9,12 +9,24 @@ import (
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
+
+	"github.com/shinagawa-web/colref/internal/orm"
 )
 
-type Reference struct {
-	File string
-	Line int
-	Text string
+// Reference is a type alias for orm.Reference for backward compatibility.
+type Reference = orm.Reference
+
+// PythonScanner implements orm.ReferenceScanner for Python codebases.
+type PythonScanner struct{}
+
+// Scan implements orm.ReferenceScanner.
+func (PythonScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
+	return Scan(dir, fieldName)
+}
+
+// SkipDirs implements orm.ReferenceScanner.
+func (PythonScanner) SkipDirs() map[string]bool {
+	return SkipDirs
 }
 
 // SkipDirs is the set of directory names that are never scanned.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -25,9 +25,13 @@ func (PythonScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
 	return Scan(dir, fieldName)
 }
 
-// SkipDirs implements orm.ReferenceScanner.
+// SkipDirs implements orm.ReferenceScanner, returning a defensive copy.
 func (PythonScanner) SkipDirs() map[string]bool {
-	return SkipDirs
+	copy := make(map[string]bool, len(SkipDirs))
+	for k, v := range SkipDirs {
+		copy[k] = v
+	}
+	return copy
 }
 
 // SkipDirs is the set of directory names that are never scanned.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -479,6 +479,26 @@ func TestLineAt_OutOfBounds(t *testing.T) {
 	}
 }
 
+func TestPythonScanner_Methods(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.email`)
+
+	s := PythonScanner{}
+
+	refs, count, err := s.Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || len(refs) != 1 {
+		t.Errorf("unexpected result: count=%d refs=%v", count, refs)
+	}
+
+	skipDirs := s.SkipDirs()
+	if !skipDirs["migrations"] {
+		t.Error("expected migrations to be in SkipDirs")
+	}
+}
+
 func TestScan_FExpression_NotDetected(t *testing.T) {
 	dir := t.TempDir()
 	// v0.1 limitation: F('email') passes the column as a string.


### PR DESCRIPTION
## Summary
- Adds `internal/orm/orm.go` with shared `Field`, `Reference` types and `SchemaParser` / `ReferenceScanner` interfaces
- Refactors `internal/parser/models.go`: `Field` becomes a type alias for `orm.Field`; adds `DjangoParser` struct implementing `orm.SchemaParser`
- Refactors `internal/scanner/scanner.go`: `Reference` becomes a type alias for `orm.Reference`; adds `PythonScanner` struct implementing `orm.ReferenceScanner`
- Updates `cmd/colref/check.go` to use `orm.Field` and `orm.Reference` for internal type references

Closes #33

## Test plan
- [ ] `go test ./...` passes (all existing tests pass without modification)
- [ ] `go build ./...` compiles cleanly
- [ ] No logic changes — pure structural refactoring