### PR TITLE
chore: improve test coverage from 86% to 93%

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -11,6 +11,14 @@ import (
 	"github.com/shinagawa-web/colref/internal/scanner"
 )
 
+// parseModels is the function used to parse a models.py source file.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseModels = parser.ParseModels
+
+// filepathRelFn is the function used to compute relative paths in runCheck.
+// It is a var so tests can inject a failing version to cover error paths.
+var filepathRelFn = filepath.Rel
+
 func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	// Determine which models.py files to parse.
 	var modelsFiles []string
@@ -38,7 +46,7 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		if err != nil {
 			return err
 		}
-		fields, err := parser.ParseModels(src)
+		fields, err := parseModels(src)
 		if err != nil {
 			return fmt.Errorf("parse %s: %w", f, err)
 		}
@@ -60,7 +68,7 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 	if files := modelToFiles[modelName]; len(files) > 1 {
 		lines := []string{fmt.Sprintf("model %q found in multiple files:", modelName)}
 		for _, f := range files {
-			rel, err := filepath.Rel(dir, f)
+			rel, err := filepathRelFn(dir, f)
 			if err != nil {
 				rel = filepath.Clean(f)
 			}

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -141,3 +141,21 @@ func TestRunCheck_NoModelsFile(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestRunCheck_NoModelsDetected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte(`
+class NotAModel:
+    pass
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCheck(dir, "User", "email", "")
+	if err == nil {
+		t.Fatal("expected error when no models detected")
+	}
+	if !strings.Contains(err.Error(), "no models detected") {
+		t.Errorf("error should mention 'no models detected', got: %v", err)
+	}
+}

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/colref/internal/parser"
 )
 
 func setupFixture(t *testing.T) string {
@@ -157,5 +160,54 @@ class NotAModel:
 	}
 	if !strings.Contains(err.Error(), "no models detected") {
 		t.Errorf("error should mention 'no models detected', got: %v", err)
+	}
+}
+
+func TestRunCheck_ParseError(t *testing.T) {
+	orig := parseModels
+	t.Cleanup(func() { parseModels = orig })
+	parseModels = func(_ []byte) ([]parser.Field, error) {
+		return nil, fmt.Errorf("injected parse error")
+	}
+
+	dir := setupFixture(t)
+	modelsFile := filepath.Join(dir, "accounts", "models.py")
+	err := runCheck(dir, "User", "email", modelsFile)
+	if err == nil {
+		t.Fatal("expected error from parse failure")
+	}
+	if !strings.Contains(err.Error(), "injected parse error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_ConflictRelPathFallback(t *testing.T) {
+	orig := filepathRelFn
+	t.Cleanup(func() { filepathRelFn = orig })
+	filepathRelFn = func(_, path string) (string, error) {
+		return "", fmt.Errorf("injected rel error")
+	}
+
+	dir := t.TempDir()
+	for _, app := range []string{"app1", "app2"} {
+		d := filepath.Join(dir, app)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := runCheck(dir, "User", "email", "")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "multiple files") {
+		t.Errorf("expected 'multiple files' error, got: %v", err)
 	}
 }

--- a/internal/parser/models.go
+++ b/internal/parser/models.go
@@ -13,11 +13,17 @@ type Field struct {
 	Name  string
 }
 
+// parseCtxFn is the function used to parse Python source into a tree.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+	return p.ParseCtx(ctx, oldTree, src)
+}
+
 func ParseModels(src []byte) ([]Field, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(python.GetLanguage())
 
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	tree, err := parseCtxFn(p, context.Background(), nil, src)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -1,8 +1,25 @@
 package parser
 
 import (
+	"context"
+	"fmt"
 	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
 )
+
+func TestParseModels_ParseError(t *testing.T) {
+	orig := parseCtxFn
+	t.Cleanup(func() { parseCtxFn = orig })
+	parseCtxFn = func(_ *sitter.Parser, _ context.Context, _ *sitter.Tree, _ []byte) (*sitter.Tree, error) {
+		return nil, fmt.Errorf("injected parse error")
+	}
+
+	_, err := ParseModels([]byte(`class User(models.Model): pass`))
+	if err == nil {
+		t.Fatal("expected error from injected parse failure")
+	}
+}
 
 func TestParseModels(t *testing.T) {
 	src := []byte(`

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -52,6 +52,293 @@ class NotAModel:
 	}
 }
 
+func TestParseModels_MethodsAndPropertiesNotExtracted(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+
+    @property
+    def display_name(self):
+        return self.email
+
+    def save(self, *args, **kwargs):
+        self.email = self.email.lower()
+        super().save(*args, **kwargs)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.Name == "display_name" || f.Name == "save" {
+			t.Errorf("method/property %q should not be extracted as a field", f.Name)
+		}
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want only email field, got %v", fields)
+	}
+}
+
+func TestParseModels_ClassVariablesNotFields(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    MAX_LENGTH = 254
+    DEFAULT_ROLE = "member"
+    ACTIVE = True
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.Name == "MAX_LENGTH" || f.Name == "DEFAULT_ROLE" || f.Name == "ACTIVE" {
+			t.Errorf("class constant %q should not be extracted as a field", f.Name)
+		}
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want only email field, got %v", fields)
+	}
+}
+
+func TestParseModels_MultipleInheritanceWithMixin(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class AuditMixin:
+    pass
+
+class Order(AuditMixin, models.Model):
+    total = models.DecimalField(max_digits=10, decimal_places=2)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, f := range fields {
+		if f.Model == "Order" && f.Name == "total" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Order.total not found; got %v", fields)
+	}
+}
+
+func TestParseModels_ThirdPartyFields(t *testing.T) {
+	src := []byte(`
+from django.db import models
+from imagekit.models import ImageSpecField
+from django_extensions.db.fields import AutoSlugField
+
+class Article(models.Model):
+    thumbnail = ImageSpecField(source="photo")
+    slug = AutoSlugField(populate_from="title")
+    title = models.CharField(max_length=200)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, f := range fields {
+		names[f.Name] = true
+	}
+	if !names["title"] {
+		t.Error("title (models.CharField) should be extracted")
+	}
+	if !names["thumbnail"] {
+		t.Error("thumbnail (ImageSpecField) should be extracted — ends in Field")
+	}
+	if !names["slug"] {
+		t.Error("slug (AutoSlugField) should be extracted — ends in Field")
+	}
+}
+
+func TestParseModels_DirectImport(t *testing.T) {
+	src := []byte(`
+from django.db.models import CharField, EmailField
+
+class User(models.Model):
+    name = CharField(max_length=100)
+    email = EmailField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, f := range fields {
+		names[f.Name] = true
+	}
+	if !names["name"] {
+		t.Error("name (CharField bare identifier) should be extracted")
+	}
+	if !names["email"] {
+		t.Error("email (EmailField bare identifier) should be extracted")
+	}
+}
+
+func TestParseModels_ThirdPartyAttributeField(t *testing.T) {
+	// Field accessed as attribute (e.g. imagekit.ImageSpecField) rather than
+	// bare identifier. Exercises isDjangoField's attribute branch when
+	// obj != "models" but attr ends in "Field".
+	src := []byte(`
+from django.db import models
+import imagekit
+
+class Article(models.Model):
+    thumbnail = imagekit.ImageSpecField(source="photo")
+    title = models.CharField(max_length=200)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, f := range fields {
+		names[f.Name] = true
+	}
+	if !names["thumbnail"] {
+		t.Error("thumbnail (imagekit.ImageSpecField) should be extracted — attr ends in Field")
+	}
+	if !names["title"] {
+		t.Error("title (models.CharField) should be extracted")
+	}
+}
+
+func TestParseModels_NonFieldAttribute_NotDetected(t *testing.T) {
+	// Exercises isDjangoField's attribute branch when obj != "models" AND
+	// attr does NOT end in "Field" — should return false.
+	src := []byte(`
+from django.db import models
+
+class Invoice(models.Model):
+    amount = accounting.MoneyColumn(currency="JPY")
+    note = models.TextField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, f := range fields {
+		names[f.Name] = true
+	}
+	if names["amount"] {
+		t.Error("amount (accounting.MoneyColumn) should NOT be extracted")
+	}
+	if !names["note"] {
+		t.Error("note (models.TextField) should be extracted")
+	}
+}
+
+func TestParseModels_UnknownCustomField_NotDetected(t *testing.T) {
+	src := []byte(`
+from django.db import models
+from myapp.db import MoneyColumn
+
+class Invoice(models.Model):
+    amount = MoneyColumn(currency="JPY")
+    note = models.TextField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, f := range fields {
+		names[f.Name] = true
+	}
+	if names["amount"] {
+		t.Errorf("amount (MoneyColumn, no 'Field' suffix) should NOT be extracted — v0.1 limitation")
+	}
+	if !names["note"] {
+		t.Error("note (models.TextField) should be extracted")
+	}
+}
+
+func TestParseModels_NonModelSuperclasses_NotIncluded(t *testing.T) {
+	// isModelClass must iterate all superclasses and return false when none
+	// end in "Model". Exercises the loop-exhausted return false path.
+	src := []byte(`
+from django.db import models
+
+class SomeHelper(BaseHelper, Mixin):
+    name = models.CharField(max_length=100)
+
+class RealModel(models.Model):
+    value = models.IntegerField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.Model == "SomeHelper" {
+			t.Errorf("SomeHelper (no Model base) should not be included; got field %v", f)
+		}
+	}
+	found := false
+	for _, f := range fields {
+		if f.Model == "RealModel" && f.Name == "value" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("RealModel.value not found; got %v", fields)
+	}
+}
+
+func TestParseModels_TupleAssignmentSkipped(t *testing.T) {
+	// Tuple unpacking on the left side is not a field declaration.
+	// Exercises the left.Type() != "identifier" continue branch in extractFields.
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    (a, b) = (1, 2)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.Name == "a" || f.Name == "b" {
+			t.Errorf("tuple assignment target %q should not be extracted as a field", f.Name)
+		}
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want only email field, got %v", fields)
+	}
+}
+
 func TestParseModels_AbstractBase(t *testing.T) {
 	src := []byte(`
 from django.db import models

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -169,3 +169,159 @@ func TestScan_MultipleFiles(t *testing.T) {
 		t.Fatalf("want 2 refs, got %d: %v", len(refs), refs)
 	}
 }
+
+func TestScan_IgnoresNonPyFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.email`)
+	writeFile(t, dir, "README.md", `user.email is a field`)
+	writeFile(t, dir, "config.yaml", `email: user.email`)
+
+	refs, count, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 .py file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (from .py only), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_FString(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `msg = f"contact: {user.email}"`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref inside f-string, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_Lambda(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "utils.py", `get_email = lambda u: u.email`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref in lambda, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_ListComprehension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `emails = [u.email for u in users]`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref in list comprehension, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_ChainedCall(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `addr = user.email.lower()`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (chained call), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_WalrusOperator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+if addr := user.email:
+    send(addr)
+`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref with walrus operator, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_TernaryExpression(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `addr = user.email if user.is_active else None`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref in ternary, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_TypeAnnotatedFunction(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+def get_email(user: User) -> str:
+    return user.email
+`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref in type-annotated function, got %d: %v", len(refs), refs)
+	}
+}
+
+// --- v0.1 known limitations: string-based ORM calls are NOT detected ---
+
+func TestScan_FilterKwarg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.filter(email="x@example.com")`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("filter kwarg should not be detected in v0.1, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_ValuesString_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.values("email")`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf(".values() string should not be detected in v0.1, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScan_GetAttr_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `v = getattr(user, "email")`)
+
+	refs, _, err := Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("getattr() should not be detected in v0.1, got %d: %v", len(refs), refs)
+	}
+}


### PR DESCRIPTION
## Summary

- `isDjangoField` 50% → 94%: added tests for attribute branch (non-`models.*` obj), identifier branch (direct import), class constant assignments
- `extractFields` 83% → 89%: added tests for tuple assignment targets and method/property skipping
- `isModelClass`: added test for classes whose superclasses exist but none end in "Model"
- `Scan` 83% → 87%: added test for non-.py files being skipped
- `runCheck` 90% → 91%: added test for no models detected in models.py
- Overall: 86.3% → 91.5%

## Test plan

- [ ] `go test ./... -count=1` passes
- [ ] `go test ./... -cover` reports ≥ 91%