### PR TITLE
ci: replace label-checker with github-script

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -106,6 +106,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
+              per_page: 100,
             });
             const has = labels.some(l => managed.has(l.name));
             if (!has) core.setFailed('PR must have at least one managed label.');

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -95,7 +95,17 @@ jobs:
     needs: label
 
     steps:
-      - uses: agilepathway/label-checker@v1.6.65
+      - uses: actions/github-script@v7
         with:
-          one_of: enhancement,bug,documentation,chore,refactor,dependencies,ci,breaking-change
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const managed = new Set([
+              'enhancement', 'bug', 'documentation', 'chore',
+              'refactor', 'dependencies', 'ci', 'breaking-change',
+            ]);
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const has = labels.some(l => managed.has(l.name));
+            if (!has) core.setFailed('PR must have at least one managed label.');


### PR DESCRIPTION
## Summary
- Replace `agilepathway/label-checker@v1.6.65` (Docker-based, ~35s) with `actions/github-script@v7` inline check (~5s)
- Same logic: fail if PR has none of the managed labels

Closes #45