### PR TITLE
chore: add benchmark tests for parser and scanner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,106 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20240604174448-3b48cf0e0164
+
+      - name: Run benchmarks on PR branch
+        run: make bench | tee new-bench.txt
+
+      - name: Save benchmark script from PR branch
+        run: cp .github/scripts/format-benchmark.sh /tmp/format-benchmark.sh
+
+      - name: Checkout main branch
+        run: |
+          git fetch origin main
+          git checkout origin/main
+
+      - name: Download dependencies for main branch
+        run: go mod download
+
+      - name: Run benchmarks on main branch
+        run: make bench | tee old-bench.txt
+
+      - name: Compare benchmarks
+        id: benchmark_comparison
+        run: |
+          echo "## Benchmark Comparison" > comparison.txt
+          echo "" >> comparison.txt
+          echo "Comparing PR branch against main branch:" >> comparison.txt
+          echo "" >> comparison.txt
+          echo "**Legend**: ✅ OK (no change or faster) | ⚠️ Caution (+10~50% slower) | ❌ Regression (+50%+ slower)" >> comparison.txt
+          echo "" >> comparison.txt
+          echo '```' >> comparison.txt
+          benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
+          bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt
+          cat formatted-comparison.txt >> comparison.txt
+          echo '```' >> comparison.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results
+          path: |
+            old-bench.txt
+            new-bench.txt
+            comparison.txt
+
+      - name: Comment PR with benchmark results
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const comparison = fs.readFileSync('comparison.txt', 'utf8');
+            const commentMarker = '<!-- benchmark-comment -->';
+            const body = commentMarker + '\n' + comparison;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes(commentMarker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            }

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -249,28 +249,173 @@ class MyModel(models.Model):
 	}
 }
 
+// BenchmarkParseModels uses a large models.py representative of a medium-sized
+// Django project (~20 models, ~100 fields) — comparable to projects like NetBox
+// or django-oscar.
 func BenchmarkParseModels(b *testing.B) {
 	src := []byte(`
 from django.db import models
+from django.contrib.auth.models import AbstractUser
 
-class User(models.Model):
-    email = models.EmailField(max_length=254)
-    name = models.CharField(max_length=100)
+class User(AbstractUser):
+    email = models.EmailField(max_length=254, unique=True)
+    display_name = models.CharField(max_length=100, blank=True)
+    bio = models.TextField(blank=True)
+    avatar = models.ImageField(upload_to="avatars/", null=True, blank=True)
+    is_verified = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
-    is_active = models.BooleanField(default=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
-class Post(models.Model):
-    title = models.CharField(max_length=200)
-    body = models.TextField()
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
-    published_at = models.DateTimeField(null=True)
+class Organisation(models.Model):
+    name = models.CharField(max_length=200)
     slug = models.SlugField(unique=True)
+    description = models.TextField(blank=True)
+    website = models.URLField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name="owned_orgs")
+
+class Membership(models.Model):
+    ROLE_CHOICES = [("admin", "Admin"), ("member", "Member"), ("viewer", "Viewer")]
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    organisation = models.ForeignKey(Organisation, on_delete=models.CASCADE)
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default="member")
+    joined_at = models.DateTimeField(auto_now_add=True)
+
+class Project(models.Model):
+    name = models.CharField(max_length=200)
+    slug = models.SlugField()
+    description = models.TextField(blank=True)
+    organisation = models.ForeignKey(Organisation, on_delete=models.CASCADE)
+    is_public = models.BooleanField(default=False)
+    archived = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+class Label(models.Model):
+    name = models.CharField(max_length=50)
+    color = models.CharField(max_length=7, default="#ededed")
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+
+class Milestone(models.Model):
+    title = models.CharField(max_length=200)
+    description = models.TextField(blank=True)
+    due_date = models.DateField(null=True, blank=True)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    closed_at = models.DateTimeField(null=True, blank=True)
+
+class Issue(models.Model):
+    STATE_OPEN = "open"
+    STATE_CLOSED = "closed"
+    STATE_CHOICES = [(STATE_OPEN, "Open"), (STATE_CLOSED, "Closed")]
+    title = models.CharField(max_length=500)
+    body = models.TextField(blank=True)
+    state = models.CharField(max_length=10, choices=STATE_CHOICES, default=STATE_OPEN)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    assignee = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name="assigned_issues")
+    milestone = models.ForeignKey(Milestone, on_delete=models.SET_NULL, null=True, blank=True)
+    labels = models.ManyToManyField(Label, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    closed_at = models.DateTimeField(null=True, blank=True)
 
 class Comment(models.Model):
-    post = models.ForeignKey(Post, on_delete=models.CASCADE)
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
     body = models.TextField()
+    issue = models.ForeignKey(Issue, on_delete=models.CASCADE)
+    author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    is_edited = models.BooleanField(default=False)
+
+class PullRequest(models.Model):
+    title = models.CharField(max_length=500)
+    body = models.TextField(blank=True)
+    state = models.CharField(max_length=10, default="open")
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    source_branch = models.CharField(max_length=200)
+    target_branch = models.CharField(max_length=200)
+    merged_at = models.DateTimeField(null=True, blank=True)
+    merged_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name="merged_prs")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class Review(models.Model):
+    VERDICT_CHOICES = [("approve", "Approve"), ("request_changes", "Request Changes"), ("comment", "Comment")]
+    pull_request = models.ForeignKey(PullRequest, on_delete=models.CASCADE)
+    reviewer = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    verdict = models.CharField(max_length=20, choices=VERDICT_CHOICES)
+    body = models.TextField(blank=True)
+    submitted_at = models.DateTimeField(auto_now_add=True)
+
+class Notification(models.Model):
+    TYPE_CHOICES = [("mention", "Mention"), ("assign", "Assign"), ("review", "Review")]
+    recipient = models.ForeignKey(User, on_delete=models.CASCADE)
+    notification_type = models.CharField(max_length=20, choices=TYPE_CHOICES)
+    is_read = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class AuditLog(models.Model):
+    ACTION_CHOICES = [("create", "Create"), ("update", "Update"), ("delete", "Delete")]
+    actor = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    action = models.CharField(max_length=10, choices=ACTION_CHOICES)
+    resource_type = models.CharField(max_length=50)
+    resource_id = models.IntegerField()
+    metadata = models.JSONField(default=dict)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class ApiToken(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+    token_hash = models.CharField(max_length=64, unique=True)
+    scopes = models.JSONField(default=list)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class Webhook(models.Model):
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    url = models.URLField()
+    secret = models.CharField(max_length=100, blank=True)
+    events = models.JSONField(default=list)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class Release(models.Model):
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    tag_name = models.CharField(max_length=100)
+    name = models.CharField(max_length=200, blank=True)
+    body = models.TextField(blank=True)
+    is_draft = models.BooleanField(default=False)
+    is_prerelease = models.BooleanField(default=False)
+    published_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+
+class Star(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+class Watch(models.Model):
+    LEVEL_CHOICES = [("all", "All"), ("issues", "Issues"), ("ignore", "Ignore")]
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
+    level = models.CharField(max_length=10, choices=LEVEL_CHOICES, default="all")
+
+class SshKey(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    title = models.CharField(max_length=200)
+    key = models.TextField()
+    fingerprint = models.CharField(max_length=100, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+
+class EmailAddress(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    email = models.EmailField(unique=True)
+    is_primary = models.BooleanField(default=False)
+    is_verified = models.BooleanField(default=False)
+    verified_at = models.DateTimeField(null=True, blank=True)
 `)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -249,11 +251,11 @@ class MyModel(models.Model):
 	}
 }
 
-// BenchmarkParseModels uses a large models.py representative of a medium-sized
-// Django project (~20 models, ~100 fields) — comparable to projects like NetBox
-// or django-oscar.
+// BenchmarkParseModels uses a models.py with 8 realistic base models plus 1,000 generated
+// ones (~12,000 lines total) — well above BookWyrm/django-oscar scale for stress testing.
 func BenchmarkParseModels(b *testing.B) {
-	src := []byte(`
+	var sb strings.Builder
+	sb.WriteString(`
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 
@@ -417,6 +419,25 @@ class EmailAddress(models.Model):
     is_verified = models.BooleanField(default=False)
     verified_at = models.DateTimeField(null=True, blank=True)
 `)
+	// Generate 1,000 additional models to scale to ~12,000 lines total.
+	for i := 0; i < 1000; i++ {
+		fmt.Fprintf(&sb,
+			"\nclass Generated%03d(models.Model):\n"+
+				"    name = models.CharField(max_length=200)\n"+
+				"    code = models.CharField(max_length=50, unique=True)\n"+
+				"    description = models.TextField(blank=True)\n"+
+				"    is_active = models.BooleanField(default=True)\n"+
+				"    priority = models.IntegerField(default=0)\n"+
+				"    score = models.FloatField(null=True, blank=True)\n"+
+				"    created_at = models.DateTimeField(auto_now_add=True)\n"+
+				"    updated_at = models.DateTimeField(auto_now=True)\n"+
+				"    owner = models.ForeignKey(\"User\", on_delete=models.CASCADE, related_name=\"gen%03d_set\")\n"+
+				"    metadata = models.JSONField(default=dict)\n",
+			i, i,
+		)
+	}
+
+	src := []byte(sb.String())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := ParseModels(src); err != nil {

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -249,6 +249,37 @@ class MyModel(models.Model):
 	}
 }
 
+func BenchmarkParseModels(b *testing.B) {
+	src := []byte(`
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField(max_length=254)
+    name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)
+    is_active = models.BooleanField(default=True)
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    published_at = models.DateTimeField(null=True)
+    slug = models.SlugField(unique=True)
+
+class Comment(models.Model):
+    post = models.ForeignKey(Post, on_delete=models.CASCADE)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    body = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseModels(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // TestIsDjangoField_ThirdPartyAttribute covers the attribute branch where the
 // object is not "models" but the attribute name ends in "Field" (third-party fields),
 // and the case where neither condition matches (returns false).


### PR DESCRIPTION
## Summary

- Add `BenchmarkParseModels` in `internal/parser/models_test.go` with a realistic multi-model Django models.py fixture
- Add `BenchmarkScan` in `internal/scanner/scanner_test.go` using a temp dir with 5 representative .py files
- Wire `make bench-compare` into `scripts/pre-push` so benchmark regressions are caught before every push

## Verification

- `make bench` produces output for both `BenchmarkParseModels` and `BenchmarkScan`
- `make check-coverage` still passes at 100%
- `make static-lint` reports 0 issues

## Test plan

- [ ] Confirm `make bench` shows benchmark lines for `internal/parser` and `internal/scanner`
- [ ] Confirm `make check-coverage` passes (100%)
- [ ] Confirm `make static-lint` passes (0 issues)
- [ ] Confirm `scripts/pre-push` now includes the `bench-compare` step

Closes #41