### PR TITLE
feat: parse db/schema.rb for Rails column definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ colref scans your codebase with an AST parser, skips comments and string literal
 ## Usage
 
 ```
-colref check --model User --field email [path]
+colref check --orm <orm> --model <Model> --field <field> [path]
 ```
 
-`path` is the directory to scan (default: current directory).
+`path` is the project root to scan (default: current directory).
+
+### Django example
+
+```
+colref check --orm django --model User --field email
+```
 
 Output:
 
@@ -39,15 +45,23 @@ References found for User.email
   notifications/tasks.py:12    instance.email
 ```
 
+### Rails example
+
+```
+colref check --orm rails --model User --field email
+```
+
+colref reads `db/schema.rb` from the project root, infers model names from table names (`users` → `User`), and scans `.rb` files for attribute-access references.
+
 ### Flags
 
 | Flag | Description |
 |---|---|
+| `--orm` | ORM type: `django`, `rails` (required) |
 | `--model` | Model name to look up (required) |
 | `--field` | Field name to search for (required) |
-| `--models-file` | Path to a specific `models.py` (see below) |
 
-### models.py auto-detection
+### Django — models.py detection
 
 colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
 
@@ -57,13 +71,7 @@ If the same model name appears in more than one `models.py`, colref exits with a
 model "User" found in multiple files:
   accounts/models.py
   legacy/models.py
-Use --models-file to specify which one.
-```
-
-Use `--models-file` to point to a specific file and resolve the ambiguity:
-
-```
-colref check --model User --field email --models-file accounts/models.py
+Use --model to disambiguate.
 ```
 
 ### Skipped directories
@@ -82,7 +90,7 @@ Binaries for Linux and macOS will be available on the [releases page](https://gi
 
 ## How it works
 
-1. Reads your ORM model file to extract the field list
+1. Reads your ORM schema source to extract the field list
 2. Walks the codebase and parses each file into an AST
 3. Reports every location where the field name appears as an attribute access (e.g. `user.email`)
 
@@ -102,7 +110,7 @@ Fields are declared explicitly in `models.py`, which makes parsing straightforwa
 
 ### v0.2 — Rails
 
-Schema is consolidated in `schema.rb`. ActiveRecord models follow predictable naming conventions (`User` → `users`), though custom table names need handling.
+Schema is consolidated in `db/schema.rb`. ActiveRecord models follow predictable naming conventions (`User` → `users`), though custom table names need handling.
 
 ### v0.3 — Laravel
 

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -39,7 +39,7 @@ func runCheckRails(dir, modelName, fieldName string) error {
 	schemaFile := filepath.Join(dir, "db", "schema.rb")
 	src, err := os.ReadFile(schemaFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("read %s: %w", schemaFile, err)
 	}
 	fields, err := parseSchemaRb(src)
 	if err != nil {

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -24,21 +24,19 @@ var parseSchemaRb = parser.ParseSchemaRb
 // It is a var so tests can inject a failing version to cover error paths.
 var filepathRelFn = filepath.Rel
 
-func runCheck(dir, modelName, fieldName, modelsFile, schemaFile string) error {
-	// Auto-detect Rails when db/schema.rb exists (or --schema-file is set).
-	if schemaFile == "" {
-		candidate := filepath.Join(dir, "db", "schema.rb")
-		if _, err := os.Stat(candidate); err == nil {
-			schemaFile = candidate
-		}
+func runCheck(dir, modelName, fieldName, ormName string) error {
+	switch ormName {
+	case "django":
+		return runCheckDjango(dir, modelName, fieldName)
+	case "rails":
+		return runCheckRails(dir, modelName, fieldName)
+	default:
+		return fmt.Errorf("unknown --orm %q: supported values are django, rails", ormName)
 	}
-	if schemaFile != "" {
-		return runCheckRails(dir, modelName, fieldName, schemaFile)
-	}
-	return runCheckDjango(dir, modelName, fieldName, modelsFile)
 }
 
-func runCheckRails(dir, modelName, fieldName, schemaFile string) error {
+func runCheckRails(dir, modelName, fieldName string) error {
+	schemaFile := filepath.Join(dir, "db", "schema.rb")
 	src, err := os.ReadFile(schemaFile)
 	if err != nil {
 		return err
@@ -47,22 +45,16 @@ func runCheckRails(dir, modelName, fieldName, schemaFile string) error {
 	if err != nil {
 		return fmt.Errorf("parse %s: %w", schemaFile, err)
 	}
-	return runCheckFields(dir, modelName, fieldName, fields, scanner.ScanRuby, "Use --schema-file to specify a different schema.")
+	return runCheckFields(dir, modelName, fieldName, fields, scanner.ScanRuby)
 }
 
-func runCheckDjango(dir, modelName, fieldName, modelsFile string) error {
-	var modelsFiles []string
-	if modelsFile != "" {
-		modelsFiles = []string{modelsFile}
-	} else {
-		var err error
-		modelsFiles, err = findModelsFiles(dir)
-		if err != nil {
-			return err
-		}
-		if len(modelsFiles) == 0 {
-			return fmt.Errorf("no models.py found under %s", dir)
-		}
+func runCheckDjango(dir, modelName, fieldName string) error {
+	modelsFiles, err := findModelsFiles(dir)
+	if err != nil {
+		return err
+	}
+	if len(modelsFiles) == 0 {
+		return fmt.Errorf("no models.py found under %s", dir)
 	}
 
 	type parsedFile struct {
@@ -102,7 +94,7 @@ func runCheckDjango(dir, modelName, fieldName, modelsFile string) error {
 			}
 			lines = append(lines, "  "+rel)
 		}
-		lines = append(lines, "Use --models-file to specify which one.")
+		lines = append(lines, "Use --model to disambiguate.")
 		return fmt.Errorf("%s", strings.Join(lines, "\n"))
 	}
 
@@ -111,10 +103,10 @@ func runCheckDjango(dir, modelName, fieldName, modelsFile string) error {
 		allFields = append(allFields, pf.fields...)
 	}
 
-	return runCheckFields(dir, modelName, fieldName, allFields, scanner.Scan, "Use --models-file to specify which one.")
+	return runCheckFields(dir, modelName, fieldName, allFields, scanner.Scan)
 }
 
-func runCheckFields(dir, modelName, fieldName string, allFields []parser.Field, scan func(string, string) ([]scanner.Reference, int, error), _ string) error {
+func runCheckFields(dir, modelName, fieldName string, allFields []parser.Field, scan func(string, string) ([]scanner.Reference, int, error)) error {
 	fieldNames := fieldsForModel(allFields, modelName)
 	if len(fieldNames) == 0 {
 		known := knownModels(allFields)

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -16,12 +16,41 @@ import (
 // It is a var so tests can inject a failing version to cover error paths.
 var parseModels = parser.ParseModels
 
+// parseSchemaRb is the function used to parse a db/schema.rb source file.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseSchemaRb = parser.ParseSchemaRb
+
 // filepathRelFn is the function used to compute relative paths in runCheck.
 // It is a var so tests can inject a failing version to cover error paths.
 var filepathRelFn = filepath.Rel
 
-func runCheck(dir, modelName, fieldName, modelsFile string) error {
-	// Determine which models.py files to parse.
+func runCheck(dir, modelName, fieldName, modelsFile, schemaFile string) error {
+	// Auto-detect Rails when db/schema.rb exists (or --schema-file is set).
+	if schemaFile == "" {
+		candidate := filepath.Join(dir, "db", "schema.rb")
+		if _, err := os.Stat(candidate); err == nil {
+			schemaFile = candidate
+		}
+	}
+	if schemaFile != "" {
+		return runCheckRails(dir, modelName, fieldName, schemaFile)
+	}
+	return runCheckDjango(dir, modelName, fieldName, modelsFile)
+}
+
+func runCheckRails(dir, modelName, fieldName, schemaFile string) error {
+	src, err := os.ReadFile(schemaFile)
+	if err != nil {
+		return err
+	}
+	fields, err := parseSchemaRb(src)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", schemaFile, err)
+	}
+	return runCheckFields(dir, modelName, fieldName, fields, scanner.ScanRuby, "Use --schema-file to specify a different schema.")
+}
+
+func runCheckDjango(dir, modelName, fieldName, modelsFile string) error {
 	var modelsFiles []string
 	if modelsFile != "" {
 		modelsFiles = []string{modelsFile}
@@ -36,7 +65,6 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		}
 	}
 
-	// Parse each file and index models → source files.
 	type parsedFile struct {
 		path   string
 		fields []orm.Field
@@ -65,7 +93,6 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		}
 	}
 
-	// Conflict: same model name in multiple files.
 	if files := modelToFiles[modelName]; len(files) > 1 {
 		lines := []string{fmt.Sprintf("model %q found in multiple files:", modelName)}
 		for _, f := range files {
@@ -84,7 +111,10 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		allFields = append(allFields, pf.fields...)
 	}
 
-	// Validate model exists.
+	return runCheckFields(dir, modelName, fieldName, allFields, scanner.Scan, "Use --models-file to specify which one.")
+}
+
+func runCheckFields(dir, modelName, fieldName string, allFields []parser.Field, scan func(string, string) ([]scanner.Reference, int, error), _ string) error {
 	fieldNames := fieldsForModel(allFields, modelName)
 	if len(fieldNames) == 0 {
 		known := knownModels(allFields)
@@ -94,14 +124,12 @@ func runCheck(dir, modelName, fieldName, modelsFile string) error {
 		return fmt.Errorf("model %q not found\nAvailable models: %s", modelName, strings.Join(known, ", "))
 	}
 
-	// Validate field exists.
 	if !containsField(fieldNames, fieldName) {
 		return fmt.Errorf("field %q not found in model %q\nAvailable fields: %s",
 			fieldName, modelName, strings.Join(fieldNames, ", "))
 	}
 
-	// Scan the codebase.
-	refs, count, err := scanner.Scan(dir, fieldName)
+	refs, count, err := scan(dir, fieldName)
 	if err != nil {
 		return err
 	}

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/shinagawa-web/colref/internal/parser"
 )
 
-func setupFixture(t *testing.T) string {
+func setupDjangoFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 
@@ -55,263 +55,6 @@ def show(post):
 	return dir
 }
 
-func TestRunCheck_RefsFound(t *testing.T) {
-	dir := setupFixture(t)
-	if err := runCheck(dir, "User", "email", "", ""); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestRunCheck_NoRefs(t *testing.T) {
-	dir := setupFixture(t)
-	if err := runCheck(dir, "User", "name", "", ""); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestRunCheck_UnknownModel(t *testing.T) {
-	dir := setupFixture(t)
-	err := runCheck(dir, "Invoice", "amount", "", "")
-	if err == nil {
-		t.Fatal("expected error for unknown model")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error should mention 'not found', got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "User") && !strings.Contains(err.Error(), "Post") {
-		t.Errorf("error should list available models, got: %v", err)
-	}
-}
-
-func TestRunCheck_UnknownField(t *testing.T) {
-	dir := setupFixture(t)
-	err := runCheck(dir, "User", "emial", "", "")
-	if err == nil {
-		t.Fatal("expected error for unknown field")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error should mention 'not found', got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "email") {
-		t.Errorf("error should list available fields, got: %v", err)
-	}
-}
-
-func TestRunCheck_Conflict(t *testing.T) {
-	dir := t.TempDir()
-	apps := []string{"app1", "app2"}
-	for _, app := range apps {
-		d := filepath.Join(dir, app)
-		if err := os.MkdirAll(d, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
-from django.db import models
-class User(models.Model):
-    email = models.EmailField()
-`), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	err := runCheck(dir, "User", "email", "", "")
-	if err == nil {
-		t.Fatal("expected conflict error")
-	}
-	if !strings.Contains(err.Error(), "multiple files") {
-		t.Errorf("error should mention 'multiple files', got: %v", err)
-	}
-	// Conflict paths should be relative (not absolute).
-	if strings.Contains(err.Error(), dir) {
-		t.Errorf("conflict paths should be relative, got: %v", err)
-	}
-}
-
-func TestRunCheck_ModelsFile(t *testing.T) {
-	dir := setupFixture(t)
-	modelsFile := filepath.Join(dir, "accounts", "models.py")
-	if err := runCheck(dir, "User", "email", modelsFile, ""); err != nil {
-		t.Fatalf("unexpected error with --models-file: %v", err)
-	}
-}
-
-func TestRunCheck_NoModelsFile(t *testing.T) {
-	dir := t.TempDir()
-	err := runCheck(dir, "User", "email", "", "")
-	if err == nil {
-		t.Fatal("expected error when no models.py found")
-	}
-	if !strings.Contains(err.Error(), "no models.py") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestRunCheck_ReadFileError covers the os.ReadFile error path in runCheck
-// when --models-file points to a non-existent path.
-func TestRunCheck_ReadFileError(t *testing.T) {
-	dir := t.TempDir()
-	err := runCheck(dir, "User", "email", "/nonexistent/path/models.py", "")
-	if err == nil {
-		t.Fatal("expected error when models-file does not exist")
-	}
-}
-
-// TestRunCheck_NoModelsDetected covers the "no models detected" branch when
-// models.py exists but contains no model classes.
-func TestRunCheck_NoModelsDetected(t *testing.T) {
-	dir := t.TempDir()
-	modelsPath := filepath.Join(dir, "models.py")
-	// A valid Python file with no model class at all.
-	if err := os.WriteFile(modelsPath, []byte("# no models here\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	err := runCheck(dir, "User", "email", modelsPath, "")
-	if err == nil {
-		t.Fatal("expected error when no models are detected")
-	}
-	if !strings.Contains(err.Error(), "no models detected") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestRunCheck_FindModelsFilesWalkError covers the WalkDir error callback in
-// findModelsFiles by passing a non-existent directory (WalkDir fails immediately).
-func TestRunCheck_FindModelsFilesWalkError(t *testing.T) {
-	err := runCheck("/nonexistent/dir/that/does/not/exist", "User", "email", "", "")
-	if err == nil {
-		t.Fatal("expected error for non-existent directory")
-	}
-}
-
-// TestRunCheck_FindModelsFilesSkipHiddenDir covers the hidden-dir and SkipDirs
-// branch in findModelsFiles — models.py inside a hidden dir should not be found.
-func TestRunCheck_FindModelsFilesSkipHiddenDir(t *testing.T) {
-	dir := t.TempDir()
-	// Put a models.py only inside a hidden dir (should be skipped).
-	hiddenDir := filepath.Join(dir, ".hidden")
-	if err := os.MkdirAll(hiddenDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(hiddenDir, "models.py"), []byte(`
-from django.db import models
-class User(models.Model):
-    email = models.EmailField()
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// No models.py in the root → should fail with "no models.py found".
-	err := runCheck(dir, "User", "email", "", "")
-	if err == nil {
-		t.Fatal("expected error: models.py in hidden dir should be skipped")
-	}
-	if !strings.Contains(err.Error(), "no models.py") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestRunCheck_ScanError covers the scanner.Scan error path by making a .py
-// file unreadable after it has been found during the walk.
-func TestRunCheck_ScanError(t *testing.T) {
-	dir := t.TempDir()
-	modelsPath := filepath.Join(dir, "models.py")
-	if err := os.WriteFile(modelsPath, []byte(`
-from django.db import models
-class User(models.Model):
-    email = models.EmailField()
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// Create a .py file that scanner will try to read but can't.
-	unreadable := filepath.Join(dir, "views.py")
-	if err := os.WriteFile(unreadable, []byte(`x = user.email`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(unreadable, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
-
-	err := runCheck(dir, "User", "email", modelsPath, "")
-	if err == nil {
-		t.Fatal("expected error when .py file is unreadable")
-	}
-}
-
-// TestCheckCmd_RunE_WithArg covers the checkCmd RunE closure when a path arg
-// is provided (len(args)==1 branch in main.go).
-func TestCheckCmd_RunE_WithArg(t *testing.T) {
-	dir := setupFixture(t)
-
-	rootCmd.SetOut(io.Discard)
-	rootCmd.SetErr(io.Discard)
-	rootCmd.SetArgs([]string{
-		"check", dir,
-		"--model", "User",
-		"--field", "email",
-	})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-// TestRunCheck_ParseModelsError covers the ParseModels error path by injecting
-// a failing parseModels function.
-func TestRunCheck_ParseModelsError(t *testing.T) {
-	origParseModels := parseModels
-	parseModels = func(src []byte) ([]parser.Field, error) {
-		return nil, fmt.Errorf("injected parse error")
-	}
-	defer func() { parseModels = origParseModels }()
-
-	dir := t.TempDir()
-	modelsPath := filepath.Join(dir, "models.py")
-	if err := os.WriteFile(modelsPath, []byte("class Foo: pass"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	err := runCheck(dir, "Foo", "bar", modelsPath, "")
-	if err == nil {
-		t.Fatal("expected error from ParseModels injection")
-	}
-	if !strings.Contains(err.Error(), "injected parse error") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestRunCheck_FilepathRelError covers the filepath.Rel error path in the conflict
-// check by injecting a failing filepathRelFn.
-func TestRunCheck_FilepathRelError(t *testing.T) {
-	origRelFn := filepathRelFn
-	filepathRelFn = func(basepath, targpath string) (string, error) {
-		return "", fmt.Errorf("injected Rel error")
-	}
-	defer func() { filepathRelFn = origRelFn }()
-
-	// Set up a conflict (same model in two files) to trigger the Rel call.
-	dir := t.TempDir()
-	for _, app := range []string{"app1", "app2"} {
-		d := filepath.Join(dir, app)
-		if err := os.MkdirAll(d, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
-from django.db import models
-class User(models.Model):
-    email = models.EmailField()
-`), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	err := runCheck(dir, "User", "email", "", "")
-	if err == nil {
-		t.Fatal("expected conflict error")
-	}
-	// The error should still mention "multiple files" even with Rel failing.
-	if !strings.Contains(err.Error(), "multiple files") {
-		t.Errorf("expected conflict error, got: %v", err)
-	}
-}
-
 func setupRailsFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -337,25 +80,276 @@ user.email
 	return dir
 }
 
-func TestRunCheck_Rails_AutoDetect(t *testing.T) {
-	dir := setupRailsFixture(t)
-	if err := runCheck(dir, "User", "email", "", ""); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestRunCheck_Rails_SchemaFile(t *testing.T) {
-	dir := setupRailsFixture(t)
-	schemaFile := filepath.Join(dir, "db", "schema.rb")
-	if err := runCheck(dir, "User", "email", "", schemaFile); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestRunCheck_Rails_ReadError(t *testing.T) {
-	err := runCheck(t.TempDir(), "User", "email", "", "/nonexistent/schema.rb")
+func TestRunCheck_UnknownOrm(t *testing.T) {
+	err := runCheck(t.TempDir(), "User", "email", "typeorm")
 	if err == nil {
-		t.Fatal("expected error for nonexistent schema file")
+		t.Fatal("expected error for unknown orm")
+	}
+	if !strings.Contains(err.Error(), "unknown --orm") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_RefsFound(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	if err := runCheck(dir, "User", "email", "django"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_NoRefs(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	if err := runCheck(dir, "User", "name", "django"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_UnknownModel(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	err := runCheck(dir, "Invoice", "amount", "django")
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "User") && !strings.Contains(err.Error(), "Post") {
+		t.Errorf("error should list available models, got: %v", err)
+	}
+}
+
+func TestRunCheck_Django_UnknownField(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	err := runCheck(dir, "User", "emial", "django")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "email") {
+		t.Errorf("error should list available fields, got: %v", err)
+	}
+}
+
+func TestRunCheck_Django_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	for _, app := range []string{"app1", "app2"} {
+		d := filepath.Join(dir, app)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "multiple files") {
+		t.Errorf("error should mention 'multiple files', got: %v", err)
+	}
+	if strings.Contains(err.Error(), dir) {
+		t.Errorf("conflict paths should be relative, got: %v", err)
+	}
+}
+
+func TestRunCheck_Django_NoModelsFile(t *testing.T) {
+	dir := t.TempDir()
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error when no models.py found")
+	}
+	if !strings.Contains(err.Error(), "no models.py") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_NoModelsDetected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte("# no models here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error when no models are detected")
+	}
+	if !strings.Contains(err.Error(), "no models detected") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_FindModelsFilesWalkError(t *testing.T) {
+	err := runCheck("/nonexistent/dir/that/does/not/exist", "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error for non-existent directory")
+	}
+}
+
+func TestRunCheck_Django_FindModelsFilesSkipHiddenDir(t *testing.T) {
+	dir := t.TempDir()
+	hiddenDir := filepath.Join(dir, ".hidden")
+	if err := os.MkdirAll(hiddenDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error: models.py in hidden dir should be skipped")
+	}
+	if !strings.Contains(err.Error(), "no models.py") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_ReadFileError(t *testing.T) {
+	dir := t.TempDir()
+	modelsPath := filepath.Join(dir, "models.py")
+	if err := os.WriteFile(modelsPath, []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(modelsPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(modelsPath, 0o644) })
+
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error when models.py is unreadable")
+	}
+}
+
+func TestRunCheck_Django_ScanError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := filepath.Join(dir, "views.py")
+	if err := os.WriteFile(unreadable, []byte(`x = user.email`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error when .py file is unreadable")
+	}
+}
+
+func TestRunCheck_Django_ParseModelsError(t *testing.T) {
+	origParseModels := parseModels
+	parseModels = func(src []byte) ([]parser.Field, error) {
+		return nil, fmt.Errorf("injected parse error")
+	}
+	defer func() { parseModels = origParseModels }()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte("class Foo: pass"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "Foo", "bar", "django")
+	if err == nil {
+		t.Fatal("expected error from ParseModels injection")
+	}
+	if !strings.Contains(err.Error(), "injected parse error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_FilepathRelError(t *testing.T) {
+	origRelFn := filepathRelFn
+	filepathRelFn = func(basepath, targpath string) (string, error) {
+		return "", fmt.Errorf("injected Rel error")
+	}
+	defer func() { filepathRelFn = origRelFn }()
+
+	dir := t.TempDir()
+	for _, app := range []string{"app1", "app2"} {
+		d := filepath.Join(dir, app)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "models.py"), []byte(`
+from django.db import models
+class User(models.Model):
+    email = models.EmailField()
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "multiple files") {
+		t.Errorf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_RefsFound(t *testing.T) {
+	dir := setupRailsFixture(t)
+	if err := runCheck(dir, "User", "email", "rails"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_NoRefs(t *testing.T) {
+	dir := setupRailsFixture(t)
+	if err := runCheck(dir, "User", "name", "rails"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_UnknownModel(t *testing.T) {
+	dir := setupRailsFixture(t)
+	err := runCheck(dir, "Invoice", "amount", "rails")
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_UnknownField(t *testing.T) {
+	dir := setupRailsFixture(t)
+	err := runCheck(dir, "User", "nonexistent", "rails")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_NoSchemaFile(t *testing.T) {
+	err := runCheck(t.TempDir(), "User", "email", "rails")
+	if err == nil {
+		t.Fatal("expected error for missing schema.rb")
 	}
 }
 
@@ -374,7 +368,7 @@ func TestRunCheck_Rails_ParseError(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dbDir, "schema.rb"), []byte("# schema"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := runCheck(dir, "User", "email", "", "")
+	err := runCheck(dir, "User", "email", "rails")
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
@@ -383,10 +377,24 @@ func TestRunCheck_Rails_ParseError(t *testing.T) {
 	}
 }
 
-// TestCheckCmd_RunE_NoArg covers the checkCmd RunE closure without a path arg
-// (default "." branch).
+func TestCheckCmd_RunE_WithArg(t *testing.T) {
+	dir := setupDjangoFixture(t)
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"check", dir,
+		"--model", "User",
+		"--field", "email",
+		"--orm", "django",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCheckCmd_RunE_NoArg(t *testing.T) {
-	dir := setupFixture(t)
+	dir := setupDjangoFixture(t)
 
 	orig, err := os.Getwd()
 	if err != nil {
@@ -403,6 +411,7 @@ func TestCheckCmd_RunE_NoArg(t *testing.T) {
 		"check",
 		"--model", "User",
 		"--field", "email",
+		"--orm", "django",
 	})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -57,21 +57,21 @@ def show(post):
 
 func TestRunCheck_RefsFound(t *testing.T) {
 	dir := setupFixture(t)
-	if err := runCheck(dir, "User", "email", ""); err != nil {
+	if err := runCheck(dir, "User", "email", "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestRunCheck_NoRefs(t *testing.T) {
 	dir := setupFixture(t)
-	if err := runCheck(dir, "User", "name", ""); err != nil {
+	if err := runCheck(dir, "User", "name", "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestRunCheck_UnknownModel(t *testing.T) {
 	dir := setupFixture(t)
-	err := runCheck(dir, "Invoice", "amount", "")
+	err := runCheck(dir, "Invoice", "amount", "", "")
 	if err == nil {
 		t.Fatal("expected error for unknown model")
 	}
@@ -85,7 +85,7 @@ func TestRunCheck_UnknownModel(t *testing.T) {
 
 func TestRunCheck_UnknownField(t *testing.T) {
 	dir := setupFixture(t)
-	err := runCheck(dir, "User", "emial", "")
+	err := runCheck(dir, "User", "emial", "", "")
 	if err == nil {
 		t.Fatal("expected error for unknown field")
 	}
@@ -114,7 +114,7 @@ class User(models.Model):
 		}
 	}
 
-	err := runCheck(dir, "User", "email", "")
+	err := runCheck(dir, "User", "email", "", "")
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}
@@ -130,14 +130,14 @@ class User(models.Model):
 func TestRunCheck_ModelsFile(t *testing.T) {
 	dir := setupFixture(t)
 	modelsFile := filepath.Join(dir, "accounts", "models.py")
-	if err := runCheck(dir, "User", "email", modelsFile); err != nil {
+	if err := runCheck(dir, "User", "email", modelsFile, ""); err != nil {
 		t.Fatalf("unexpected error with --models-file: %v", err)
 	}
 }
 
 func TestRunCheck_NoModelsFile(t *testing.T) {
 	dir := t.TempDir()
-	err := runCheck(dir, "User", "email", "")
+	err := runCheck(dir, "User", "email", "", "")
 	if err == nil {
 		t.Fatal("expected error when no models.py found")
 	}
@@ -150,7 +150,7 @@ func TestRunCheck_NoModelsFile(t *testing.T) {
 // when --models-file points to a non-existent path.
 func TestRunCheck_ReadFileError(t *testing.T) {
 	dir := t.TempDir()
-	err := runCheck(dir, "User", "email", "/nonexistent/path/models.py")
+	err := runCheck(dir, "User", "email", "/nonexistent/path/models.py", "")
 	if err == nil {
 		t.Fatal("expected error when models-file does not exist")
 	}
@@ -165,7 +165,7 @@ func TestRunCheck_NoModelsDetected(t *testing.T) {
 	if err := os.WriteFile(modelsPath, []byte("# no models here\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := runCheck(dir, "User", "email", modelsPath)
+	err := runCheck(dir, "User", "email", modelsPath, "")
 	if err == nil {
 		t.Fatal("expected error when no models are detected")
 	}
@@ -177,7 +177,7 @@ func TestRunCheck_NoModelsDetected(t *testing.T) {
 // TestRunCheck_FindModelsFilesWalkError covers the WalkDir error callback in
 // findModelsFiles by passing a non-existent directory (WalkDir fails immediately).
 func TestRunCheck_FindModelsFilesWalkError(t *testing.T) {
-	err := runCheck("/nonexistent/dir/that/does/not/exist", "User", "email", "")
+	err := runCheck("/nonexistent/dir/that/does/not/exist", "User", "email", "", "")
 	if err == nil {
 		t.Fatal("expected error for non-existent directory")
 	}
@@ -200,7 +200,7 @@ class User(models.Model):
 		t.Fatal(err)
 	}
 	// No models.py in the root → should fail with "no models.py found".
-	err := runCheck(dir, "User", "email", "")
+	err := runCheck(dir, "User", "email", "", "")
 	if err == nil {
 		t.Fatal("expected error: models.py in hidden dir should be skipped")
 	}
@@ -231,7 +231,7 @@ class User(models.Model):
 	}
 	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
 
-	err := runCheck(dir, "User", "email", modelsPath)
+	err := runCheck(dir, "User", "email", modelsPath, "")
 	if err == nil {
 		t.Fatal("expected error when .py file is unreadable")
 	}
@@ -268,7 +268,7 @@ func TestRunCheck_ParseModelsError(t *testing.T) {
 	if err := os.WriteFile(modelsPath, []byte("class Foo: pass"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := runCheck(dir, "Foo", "bar", modelsPath)
+	err := runCheck(dir, "Foo", "bar", modelsPath, "")
 	if err == nil {
 		t.Fatal("expected error from ParseModels injection")
 	}
@@ -302,13 +302,84 @@ class User(models.Model):
 		}
 	}
 
-	err := runCheck(dir, "User", "email", "")
+	err := runCheck(dir, "User", "email", "", "")
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}
 	// The error should still mention "multiple files" even with Rel failing.
 	if !strings.Contains(err.Error(), "multiple files") {
 		t.Errorf("expected conflict error, got: %v", err)
+	}
+}
+
+func setupRailsFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "schema.rb"), []byte(`
+ActiveRecord::Schema[7.0].define do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name"
+  end
+end
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.rb"), []byte(`
+user.email
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestRunCheck_Rails_AutoDetect(t *testing.T) {
+	dir := setupRailsFixture(t)
+	if err := runCheck(dir, "User", "email", "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_SchemaFile(t *testing.T) {
+	dir := setupRailsFixture(t)
+	schemaFile := filepath.Join(dir, "db", "schema.rb")
+	if err := runCheck(dir, "User", "email", "", schemaFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_ReadError(t *testing.T) {
+	err := runCheck(t.TempDir(), "User", "email", "", "/nonexistent/schema.rb")
+	if err == nil {
+		t.Fatal("expected error for nonexistent schema file")
+	}
+}
+
+func TestRunCheck_Rails_ParseError(t *testing.T) {
+	origParse := parseSchemaRb
+	parseSchemaRb = func(src []byte) ([]parser.Field, error) {
+		return nil, fmt.Errorf("injected schema parse error")
+	}
+	defer func() { parseSchemaRb = origParse }()
+
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "schema.rb"), []byte("# schema"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "User", "email", "", "")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "injected schema parse error") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -24,10 +24,9 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	flagModel      string
-	flagField      string
-	flagModelsFile string
-	flagSchemaFile string
+	flagModel string
+	flagField string
+	flagOrm   string
 )
 
 var checkCmd = &cobra.Command{
@@ -39,17 +38,17 @@ var checkCmd = &cobra.Command{
 		if len(args) == 1 {
 			dir = args[0]
 		}
-		return runCheck(dir, flagModel, flagField, flagModelsFile, flagSchemaFile)
+		return runCheck(dir, flagModel, flagField, flagOrm)
 	},
 }
 
 func init() {
 	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
 	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
-	checkCmd.Flags().StringVar(&flagModelsFile, "models-file", "", "Path to models.py (auto-detected if omitted)")
-	checkCmd.Flags().StringVar(&flagSchemaFile, "schema-file", "", "Path to db/schema.rb (auto-detected if omitted)")
+	checkCmd.Flags().StringVar(&flagOrm, "orm", "", "ORM type: django, rails")
 	_ = checkCmd.MarkFlagRequired("model")
 	_ = checkCmd.MarkFlagRequired("field")
+	_ = checkCmd.MarkFlagRequired("orm")
 
 	rootCmd.AddCommand(checkCmd)
 }

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -27,6 +27,7 @@ var (
 	flagModel      string
 	flagField      string
 	flagModelsFile string
+	flagSchemaFile string
 )
 
 var checkCmd = &cobra.Command{
@@ -38,7 +39,7 @@ var checkCmd = &cobra.Command{
 		if len(args) == 1 {
 			dir = args[0]
 		}
-		return runCheck(dir, flagModel, flagField, flagModelsFile)
+		return runCheck(dir, flagModel, flagField, flagModelsFile, flagSchemaFile)
 	},
 }
 
@@ -46,6 +47,7 @@ func init() {
 	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
 	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
 	checkCmd.Flags().StringVar(&flagModelsFile, "models-file", "", "Path to models.py (auto-detected if omitted)")
+	checkCmd.Flags().StringVar(&flagSchemaFile, "schema-file", "", "Path to db/schema.rb (auto-detected if omitted)")
 	_ = checkCmd.MarkFlagRequired("model")
 	_ = checkCmd.MarkFlagRequired("field")
 

--- a/internal/parser/schema_rb.go
+++ b/internal/parser/schema_rb.go
@@ -1,0 +1,161 @@
+package parser
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/ruby"
+
+	"github.com/shinagawa-web/colref/internal/orm"
+)
+
+// RailsParser implements orm.SchemaParser for Rails db/schema.rb files.
+type RailsParser struct{}
+
+// ParseSchema implements orm.SchemaParser.
+func (RailsParser) ParseSchema(src []byte) ([]orm.Field, error) {
+	return ParseSchemaRb(src)
+}
+
+// parseCtxFnRuby is the function used to parse Ruby source into a tree.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseCtxFnRuby = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+	return p.ParseCtx(ctx, oldTree, src)
+}
+
+// ParseSchemaRb parses a Rails db/schema.rb file and returns all column
+// definitions as Fields. The Model name is inferred from the table name via
+// a simple singularize+CamelCase heuristic; self.table_name overrides are
+// not handled (v0.1 limitation).
+func ParseSchemaRb(src []byte) ([]Field, error) {
+	p := sitter.NewParser()
+	p.SetLanguage(ruby.GetLanguage())
+
+	tree, err := parseCtxFnRuby(p, context.Background(), nil, src)
+	if err != nil {
+		return nil, err
+	}
+
+	var fields []Field
+	walkSchemaNode(tree.RootNode(), src, &fields)
+	return fields, nil
+}
+
+// walkSchemaNode recursively walks the AST looking for create_table calls.
+func walkSchemaNode(node *sitter.Node, src []byte, fields *[]Field) {
+	if node.Type() == "call" {
+		method := node.ChildByFieldName("method")
+		receiver := node.ChildByFieldName("receiver")
+		if receiver == nil && method != nil && method.Content(src) == "create_table" {
+			extractTableFields(node, src, fields)
+			return
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkSchemaNode(node.Child(i), src, fields)
+	}
+}
+
+// extractTableFields extracts column names from a single create_table block.
+func extractTableFields(callNode *sitter.Node, src []byte, fields *[]Field) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	tableName := firstStringArg(args, src)
+	if tableName == "" {
+		return
+	}
+	modelName := tableToModel(tableName)
+
+	doBlock := findChild(callNode, "do_block")
+	if doBlock == nil {
+		return
+	}
+	body := findChild(doBlock, "body_statement")
+	if body == nil {
+		return
+	}
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		stmt := body.Child(i)
+		if stmt.Type() != "call" {
+			continue
+		}
+		colArgs := stmt.ChildByFieldName("arguments")
+		if colArgs == nil {
+			continue
+		}
+		colName := firstStringArg(colArgs, src)
+		if colName == "" {
+			continue
+		}
+		*fields = append(*fields, Field{Model: modelName, Name: colName})
+	}
+}
+
+// firstStringArg returns the content of the first string argument in an
+// argument_list node, or "" if no string argument is present.
+func firstStringArg(argList *sitter.Node, src []byte) string {
+	for i := 0; i < int(argList.ChildCount()); i++ {
+		child := argList.Child(i)
+		if child.Type() == "string" {
+			for j := 0; j < int(child.ChildCount()); j++ {
+				c := child.Child(j)
+				if c.Type() == "string_content" {
+					return c.Content(src)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// findChild returns the first direct child of node with the given type.
+func findChild(node *sitter.Node, typ string) *sitter.Node {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(i)
+		if child.Type() == typ {
+			return child
+		}
+	}
+	return nil
+}
+
+// tableToModel converts a Rails table name (e.g. "order_items") to a model
+// name (e.g. "OrderItem") using a simple singularize+CamelCase heuristic.
+// Irregular plurals (e.g. people→Person) are not handled (v0.1 limitation).
+func tableToModel(table string) string {
+	words := strings.Split(table, "_")
+	for i, w := range words {
+		if i == len(words)-1 {
+			w = singularize(w)
+		}
+		words[i] = capitalize(w)
+	}
+	return strings.Join(words, "")
+}
+
+func singularize(word string) string {
+	switch {
+	case strings.HasSuffix(word, "ies") && len(word) > 3:
+		return word[:len(word)-3] + "y"
+	case strings.HasSuffix(word, "sses"):
+		return word[:len(word)-2]
+	case strings.HasSuffix(word, "s") && len(word) > 1:
+		return word[:len(word)-1]
+	default:
+		return word
+	}
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return ""
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}

--- a/internal/parser/schema_rb_test.go
+++ b/internal/parser/schema_rb_test.go
@@ -1,0 +1,268 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func TestRailsParser_ParseSchema(t *testing.T) {
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+  end
+end
+`)
+	fields, err := RailsParser{}.ParseSchema(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want email field, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_ParseError(t *testing.T) {
+	orig := parseCtxFnRuby
+	t.Cleanup(func() { parseCtxFnRuby = orig })
+	parseCtxFnRuby = func(_ *sitter.Parser, _ context.Context, _ *sitter.Tree, _ []byte) (*sitter.Tree, error) {
+		return nil, fmt.Errorf("injected parse error")
+	}
+
+	_, err := ParseSchemaRb([]byte(`ActiveRecord::Schema.define do; end`))
+	if err == nil {
+		t.Fatal("expected error from injected parse failure")
+	}
+}
+
+func TestParseSchemaRb(t *testing.T) {
+	src := []byte(`
+ActiveRecord::Schema[7.0].define(version: 2024_01_15_000000) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name", limit: 100
+    t.integer "role", default: 0
+    t.timestamps
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []Field{
+		{Model: "User", Name: "email"},
+		{Model: "User", Name: "name"},
+		{Model: "User", Name: "role"},
+		{Model: "Post", Name: "title"},
+		{Model: "Post", Name: "body"},
+		{Model: "Post", Name: "user_id"},
+	}
+
+	if len(fields) != len(want) {
+		t.Fatalf("got %d fields, want %d\ngot: %v", len(fields), len(want), fields)
+	}
+	for i, f := range fields {
+		if f != want[i] {
+			t.Errorf("fields[%d] = %v, want %v", i, f, want[i])
+		}
+	}
+}
+
+func TestParseSchemaRb_IndexSkipped(t *testing.T) {
+	// t.index has an array as first arg, not a string — should be skipped.
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range fields {
+		if f.Name == "email" && f.Model == "User" {
+			continue
+		}
+		if f.Name != "email" {
+			t.Errorf("unexpected field %v — index should be skipped", f)
+		}
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want only email, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_TimestampsSkipped(t *testing.T) {
+	// t.timestamps has no string arg — should be skipped (v0.1 limitation).
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.timestamps
+  end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 1 || fields[0].Name != "title" {
+		t.Errorf("want only title, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_NoArgsCreateTable(t *testing.T) {
+	// create_table without an argument_list should be silently skipped.
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table do |t|
+    t.string "name"
+  end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields for create_table without table name, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_NonStringTableName(t *testing.T) {
+	// create_table with a non-string first arg should be silently skipped.
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table :users, force: :cascade do |t|
+    t.string "email"
+  end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields for symbol table name, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_NoDoBlock(t *testing.T) {
+	// create_table without a do block should be silently skipped.
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table "users", force: :cascade
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields when no do block, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_EmptyDoBlock(t *testing.T) {
+	// do block with no body_statement → body == nil → silently skipped.
+	src := []byte(`
+ActiveRecord::Schema.define do
+  create_table "users" do end
+end
+`)
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields for empty do block, got %v", fields)
+	}
+}
+
+func TestParseSchemaRb_NonCallBodyStatement(t *testing.T) {
+	// A bare string literal inside the do block produces a non-call statement.
+	// It should be skipped while other column calls are still extracted.
+	src := []byte("ActiveRecord::Schema.define do\n  create_table \"users\" do |t|\n    \"bare string\"\n    t.string \"email\"\n  end\nend\n")
+
+	fields, err := ParseSchemaRb(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 1 || fields[0].Name != "email" {
+		t.Errorf("want only email, got %v", fields)
+	}
+}
+
+func TestTableToModel(t *testing.T) {
+	cases := []struct {
+		table string
+		model string
+	}{
+		{"users", "User"},
+		{"posts", "Post"},
+		{"categories", "Category"},
+		{"addresses", "Address"},
+		{"order_items", "OrderItem"},
+		{"admin_users", "AdminUser"},
+		{"data", "Data"},
+	}
+	for _, c := range cases {
+		got := tableToModel(c.table)
+		if got != c.model {
+			t.Errorf("tableToModel(%q) = %q, want %q", c.table, got, c.model)
+		}
+	}
+}
+
+func TestSingularize(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"users", "user"},
+		{"posts", "post"},
+		{"categories", "category"},
+		{"addresses", "address"},
+		{"items", "item"},
+		{"data", "data"},
+		{"s", "s"},
+		{"ies", "ie"},
+	}
+	for _, c := range cases {
+		got := singularize(c.in)
+		if got != c.out {
+			t.Errorf("singularize(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+	if got := capitalize(""); got != "" {
+		t.Errorf("capitalize(%q) = %q, want %q", "", got, "")
+	}
+	if got := capitalize("user"); got != "User" {
+		t.Errorf("capitalize(%q) = %q, want %q", "user", got, "User")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -10,6 +10,7 @@ import (
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
+	"github.com/smacker/go-tree-sitter/ruby"
 
 	"github.com/shinagawa-web/colref/internal/orm"
 )
@@ -27,6 +28,23 @@ func (PythonScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
 
 // SkipDirs implements orm.ReferenceScanner, returning a defensive copy.
 func (PythonScanner) SkipDirs() map[string]bool {
+	copy := make(map[string]bool, len(SkipDirs))
+	for k, v := range SkipDirs {
+		copy[k] = v
+	}
+	return copy
+}
+
+// RubyScanner implements orm.ReferenceScanner for Ruby codebases.
+type RubyScanner struct{}
+
+// Scan implements orm.ReferenceScanner.
+func (RubyScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
+	return ScanRuby(dir, fieldName)
+}
+
+// SkipDirs implements orm.ReferenceScanner, returning a defensive copy.
+func (RubyScanner) SkipDirs() map[string]bool {
 	copy := make(map[string]bool, len(SkipDirs))
 	for k, v := range SkipDirs {
 		copy[k] = v
@@ -56,7 +74,18 @@ var filepathRelFn = filepath.Rel
 // Scan walks dir and returns every attribute-access node whose attribute name
 // equals fieldName, along with the total number of .py files examined.
 func Scan(dir, fieldName string) ([]Reference, int, error) {
-	lang := python.GetLanguage()
+	return scanFiles(dir, fieldName, ".py", python.GetLanguage(), walkNode)
+}
+
+// ScanRuby walks dir and returns every method-call node whose method name
+// equals fieldName, along with the total number of .rb files examined.
+func ScanRuby(dir, fieldName string) ([]Reference, int, error) {
+	return scanFiles(dir, fieldName, ".rb", ruby.GetLanguage(), walkNodeRuby)
+}
+
+type walkFn func(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference)
+
+func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn) ([]Reference, int, error) {
 	var refs []Reference
 	filesScanned := 0
 
@@ -71,7 +100,7 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".py") {
+		if !strings.HasSuffix(path, ext) {
 			return nil
 		}
 		filesScanned++
@@ -94,7 +123,7 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 		}
 		lines := bytes.Split(src, []byte("\n"))
 		var fileRefs []Reference
-		walkNode(tree.RootNode(), src, lines, fieldName, rel, &fileRefs)
+		walk(tree.RootNode(), src, lines, fieldName, rel, &fileRefs)
 		refs = append(refs, dedupeByLine(fileRefs)...)
 		return nil
 	})
@@ -120,6 +149,29 @@ func lineAt(lines [][]byte, row int) string {
 		return string(lines[row])
 	}
 	return ""
+}
+
+// walkNodeRuby matches Ruby method calls (call nodes) where the method name
+// equals fieldName, e.g. user.email → matches "email".
+func walkNodeRuby(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
+	if node.Type() == "call" {
+		method := node.ChildByFieldName("method")
+		if method != nil && method.Content(src) == fieldName {
+			methodRow := int(method.StartPoint().Row)
+			text := node.Content(src)
+			if int(node.StartPoint().Row) != methodRow {
+				text = strings.TrimSpace(lineAt(lines, methodRow))
+			}
+			*refs = append(*refs, Reference{
+				File: file,
+				Line: methodRow + 1,
+				Text: text,
+			})
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkNodeRuby(node.Child(i), src, lines, fieldName, file, refs)
+	}
 }
 
 func walkNode(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -512,3 +512,405 @@ func TestScan_FExpression_NotDetected(t *testing.T) {
 		t.Errorf("F() expression should not be detected in v0.1, got %d: %v", len(refs), refs)
 	}
 }
+
+func TestScanRuby_BasicMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `
+def show
+  render json: user.email
+end
+`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "user.email" {
+		t.Errorf("want text %q, got %q", "user.email", refs[0].Text)
+	}
+	if refs[0].Line != 3 {
+		t.Errorf("want line 3, got %d", refs[0].Line)
+	}
+}
+
+func TestScanRuby_SkipNonRbFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `return user.email`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 .rb files scanned, got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want no refs from .py file, got %v", refs)
+	}
+}
+
+func TestScanRuby_MultiLine(t *testing.T) {
+	dir := t.TempDir()
+	// Method on a different line than the receiver.
+	writeFile(t, dir, "app.rb", "user\n  .email\n")
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for multi-line chain, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 2 {
+		t.Errorf("want line 2 (method line), got %d", refs[0].Line)
+	}
+	if refs[0].Text != ".email" {
+		t.Errorf("want trimmed method line %q, got %q", ".email", refs[0].Text)
+	}
+}
+
+func TestScanRuby_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `user.name`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want no refs, got %v", refs)
+	}
+}
+
+func TestRubyScanner_Methods(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `user.email`)
+
+	s := RubyScanner{}
+
+	refs, count, err := s.Scan(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || len(refs) != 1 {
+		t.Errorf("unexpected result: count=%d refs=%v", count, refs)
+	}
+
+	skipDirs := s.SkipDirs()
+	if !skipDirs["node_modules"] {
+		t.Error("expected node_modules to be in SkipDirs")
+	}
+}
+
+// BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
+// per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
+// in line density while exceeding it in file count.
+func BenchmarkScan(b *testing.B) {
+	dir := b.TempDir()
+
+	const viewsFmt = `
+from django.shortcuts import get_object_or_404, render
+from django.http import JsonResponse
+from django.views import View
+from django.contrib.auth.decorators import login_required
+
+def list_%[1]d(request):
+    qs = User.objects.filter(is_active=True).select_related("profile")
+    return JsonResponse([u.email for u in qs], safe=False)
+
+def detail_%[1]d(request, pk):
+    user = get_object_or_404(User, pk=pk)
+    return JsonResponse({"id": user.pk, "email": user.email, "name": user.display_name})
+
+def create_%[1]d(request):
+    email = request.POST.get("email")
+    if User.objects.filter(email=email).exists():
+        return JsonResponse({"error": "email taken"}, status=400)
+    user = User.objects.create(email=email, display_name=request.POST.get("name", ""))
+    return JsonResponse({"id": user.pk, "email": user.email}, status=201)
+
+def update_%[1]d(request, pk):
+    user = get_object_or_404(User, pk=pk)
+    user.display_name = request.POST.get("name", user.display_name)
+    user.save()
+    return JsonResponse({"email": user.email, "name": user.display_name})
+
+def delete_%[1]d(request, pk):
+    user = get_object_or_404(User, pk=pk)
+    email = user.email
+    user.delete()
+    return JsonResponse({"deleted": email})
+
+@login_required
+def profile_%[1]d(request):
+    return render(request, "profile.html", {
+        "email": request.user.email,
+        "name": request.user.display_name,
+    })
+
+class App%[1]dListView(View):
+    def get(self, request):
+        users = User.objects.filter(is_active=True).order_by("-created_at")
+        data = [{"id": u.pk, "email": u.email, "name": u.display_name} for u in users]
+        return JsonResponse({"results": data, "count": len(data)})
+
+class App%[1]dDetailView(View):
+    def get(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        return JsonResponse({"id": user.pk, "email": user.email, "verified": user.is_verified})
+
+    def patch(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        if name := request.POST.get("name"):
+            user.display_name = name
+        user.save()
+        return JsonResponse({"email": user.email})
+
+    def delete(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        email = user.email
+        user.delete()
+        return JsonResponse({"deleted": email})
+
+class App%[1]dCreateView(View):
+    def post(self, request):
+        email = request.POST["email"]
+        if User.objects.filter(email=email).exists():
+            return JsonResponse({"error": "email taken"}, status=400)
+        user = User.objects.create(email=email, display_name=request.POST.get("name", ""))
+        return JsonResponse({"id": user.pk, "email": user.email}, status=201)
+
+class App%[1]dUpdateView(View):
+    def post(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        user.display_name = request.POST.get("name", user.display_name)
+        user.bio = request.POST.get("bio", user.bio)
+        user.save()
+        return JsonResponse({"email": user.email, "name": user.display_name})
+
+class App%[1]dDeleteView(View):
+    def post(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        email = user.email
+        user.delete()
+        return JsonResponse({"deleted": email})
+`
+
+	const serializersFmt = `
+class App%[1]dUserSerializer:
+    def to_representation(self, instance):
+        return {
+            "id": instance.pk,
+            "email": instance.email,
+            "name": instance.display_name,
+            "verified": instance.is_verified,
+            "bio": instance.bio,
+        }
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise ValueError("email already in use")
+        return value
+
+    def validate_display_name(self, value):
+        if len(value) < 2:
+            raise ValueError("display_name too short")
+        return value
+
+class App%[1]dDetailSerializer(App%[1]dUserSerializer):
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["avatar"] = instance.avatar.url if instance.avatar else None
+        return data
+
+class App%[1]dListSerializer(App%[1]dUserSerializer):
+    def to_representation(self, instance):
+        return {"id": instance.pk, "email": instance.email, "name": instance.display_name}
+
+class App%[1]dCreateSerializer:
+    def validate(self, data):
+        if not data.get("email"):
+            raise ValueError("email required")
+        if User.objects.filter(email=data["email"]).exists():
+            raise ValueError("email taken")
+        return data
+
+    def create(self, validated_data):
+        user = User(**validated_data)
+        user.save()
+        return user
+
+class App%[1]dUpdateSerializer:
+    def update(self, instance, validated_data):
+        instance.display_name = validated_data.get("display_name", instance.display_name)
+        instance.bio = validated_data.get("bio", instance.bio)
+        instance.save()
+        return instance
+
+    def to_representation(self, instance):
+        return {"email": instance.email, "name": instance.display_name}
+`
+
+	const tasksFmt = `
+from celery import shared_task
+
+@shared_task
+def send_welcome_%[1]d(user_id):
+    user = User.objects.get(pk=user_id)
+    send_mail(subject="Welcome", message=f"Hi {user.display_name}", recipient_list=[user.email])
+
+@shared_task
+def send_notification_%[1]d(user_id, message):
+    user = User.objects.get(pk=user_id)
+    if user.is_verified:
+        notify(user.email, message)
+
+@shared_task
+def deactivate_unverified_%[1]d():
+    for user in User.objects.filter(is_verified=False):
+        log(f"deactivating {user.email}")
+        user.is_active = False
+        user.save()
+
+@shared_task
+def send_reset_%[1]d(user_id):
+    user = User.objects.get(pk=user_id)
+    token = generate_token(user.pk)
+    send_mail(subject="Reset", message=f"Reset for {user.email}: /reset/{token}", recipient_list=[user.email])
+
+@shared_task
+def send_verification_%[1]d(user_id):
+    user = User.objects.get(pk=user_id)
+    if not user.is_verified:
+        code = generate_code(user.pk)
+        send_mail(subject="Verify", message=f"Verify {user.email}: /verify/{code}", recipient_list=[user.email])
+
+@shared_task
+def sync_to_crm_%[1]d(user_id):
+    user = User.objects.get(pk=user_id)
+    crm.upsert({"email": user.email, "name": user.display_name, "verified": user.is_verified})
+
+@shared_task
+def cleanup_inactive_%[1]d():
+    for user in User.objects.filter(is_active=False):
+        log(f"removing {user.email}")
+        user.delete()
+`
+
+	const adminFmt = `
+from django.contrib import admin
+from django.utils.html import format_html
+
+@admin.register(User)
+class App%[1]dUserAdmin(admin.ModelAdmin):
+    list_display = ["email", "display_name", "is_verified", "is_active", "created_at"]
+    list_filter = ["is_verified", "is_active", "created_at"]
+    search_fields = ["email", "display_name"]
+    readonly_fields = ["created_at", "updated_at"]
+    ordering = ["-created_at"]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related()
+
+    def email_link(self, obj):
+        return format_html('<a href="mailto:{}">{}</a>', obj.email, obj.email)
+    email_link.short_description = "Email"
+
+    def verify_users(self, request, queryset):
+        updated = queryset.update(is_verified=True)
+        self.message_user(request, f"{updated} users verified.")
+    verify_users.short_description = "Mark selected users as verified"
+
+    def deactivate_users(self, request, queryset):
+        for user in queryset:
+            log(f"admin deactivated {user.email}")
+        queryset.update(is_active=False)
+    deactivate_users.short_description = "Deactivate selected users"
+
+    actions = ["verify_users", "deactivate_users"]
+
+@admin.register(Organisation)
+class App%[1]dOrgAdmin(admin.ModelAdmin):
+    list_display = ["name", "slug", "owner_email", "created_at"]
+    search_fields = ["name", "slug"]
+    readonly_fields = ["created_at"]
+
+    def owner_email(self, obj):
+        return obj.owner.email
+    owner_email.short_description = "Owner"
+`
+
+	const signalsFmt = `
+from django.db.models.signals import post_save, pre_delete, post_delete
+from django.dispatch import receiver
+
+@receiver(post_save, sender=User)
+def on_created_%[1]d(sender, instance, created, **kwargs):
+    if created:
+        send_welcome_%[1]d.delay(instance.pk)
+        log(f"new user: {instance.email}")
+
+@receiver(post_save, sender=User)
+def on_updated_%[1]d(sender, instance, created, **kwargs):
+    if not created and instance.is_verified:
+        cache.set(f"user:{instance.pk}:email", instance.email)
+
+@receiver(post_save, sender=User)
+def on_verified_%[1]d(sender, instance, created, **kwargs):
+    if not created and instance.is_verified:
+        send_mail("Verified", f"Account {instance.email} verified.", [instance.email])
+
+@receiver(pre_delete, sender=User)
+def on_pre_delete_%[1]d(sender, instance, **kwargs):
+    log(f"about to delete: {instance.email}")
+    cache.delete(f"user:{instance.pk}:email")
+
+@receiver(post_delete, sender=User)
+def on_deleted_%[1]d(sender, instance, **kwargs):
+    log(f"deleted: {instance.email}")
+    audit_log.record("delete", "User", instance.email)
+
+@receiver(post_save, sender=Organisation)
+def on_org_created_%[1]d(sender, instance, created, **kwargs):
+    if created:
+        notify(instance.owner.email, f"Org '{instance.name}' created")
+`
+
+	formats := []struct {
+		suffix string
+		format string
+	}{
+		{"views", viewsFmt},
+		{"serializers", serializersFmt},
+		{"tasks", tasksFmt},
+		{"admin", adminFmt},
+		{"signals", signalsFmt},
+	}
+
+	for i := 0; i < 200; i++ {
+		appDir := filepath.Join(dir, fmt.Sprintf("app%03d", i))
+		if err := os.MkdirAll(appDir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		for _, f := range formats {
+			content := fmt.Sprintf(f.format, i)
+			path := filepath.Join(appDir, f.suffix+".py")
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := Scan(dir, "email"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -10,4 +10,14 @@ make static-lint
 echo "==> Running tests with coverage check..."
 make check-coverage
 
+if [ "${SKIP_BENCH_COMPARE:-0}" = "1" ]; then
+    echo "==> Skipping benchmark comparison (SKIP_BENCH_COMPARE=1)."
+elif command -v benchstat >/dev/null 2>&1; then
+    echo "==> Running benchmark comparison..."
+    make bench-compare
+else
+    echo "==> benchstat not found; running benchmarks without comparison..."
+    make bench
+fi
+
 echo "==> All checks passed."


### PR DESCRIPTION
## Summary

- **`internal/parser/schema_rb.go`**: `ParseSchemaRb` walks the Ruby tree-sitter AST for `create_table` blocks, extracts column names, and inflects table names to model names (singularize + CamelCase heuristic)
- **`internal/scanner/scanner.go`**: `ScanRuby` scans `.rb` files and matches Ruby `call` nodes where `method == fieldName`; `Scan` and `ScanRuby` share a common `scanFiles` internal implementation
- **`cmd/colref/`**: `--orm django|rails` flag (required); replaces auto-detection and removes `--models-file`/`--schema-file`
- **`README.md`**: updated to document the new `--orm` flag CLI

## Known limitations (v0.1)

- `self.table_name` overrides in model files are not handled
- `t.timestamps` is skipped (not expanded to `created_at`/`updated_at`)
- Irregular plurals (`people` → `Person`) are not inflected

## Test plan

- [x] `make check-coverage` → 100% across all packages
- [x] `make static-lint` → 0 issues
- [x] Pre-push hook passes

Closes #34
Closes #37