### PR TITLE
feat: add e2e tests against the built binary

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -27,6 +27,7 @@ jobs:
               { pattern: /^refactor(\(.+\))?(!)?:/,      label: 'refactor' },
               { pattern: /^(deps|dependencies)(\(.+\))?(!)?:/, label: 'dependencies' },
               { pattern: /^ci(\(.+\))?(!)?:/,            label: 'ci' },
+              { pattern: /^test(\(.+\))?(!)?:/,          label: 'test' },
             ];
 
             const managedLabels = new Set([
@@ -100,7 +101,7 @@ jobs:
           script: |
             const managed = new Set([
               'enhancement', 'bug', 'documentation', 'chore',
-              'refactor', 'dependencies', 'ci', 'breaking-change',
+              'refactor', 'dependencies', 'ci', 'breaking-change', 'test',
             ]);
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           cache: true
 
       - name: Run tests
-        run: go test -race -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out $(go list ./... | grep -v /e2e)
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+colref
+e2e/colref-e2e-test
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-coverage check-coverage bench bench-compare clean install static-lint lint-fix install-hooks mod-tidy help
+.PHONY: build test test-e2e build-e2e clean-e2e test-coverage check-coverage bench bench-compare clean install static-lint lint-fix install-hooks mod-tidy help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -35,11 +35,24 @@ test-coverage: ## Run tests with coverage (report only)
 	$(GOCMD) tool cover -html=coverage/coverage.out -o coverage/coverage.html
 	@echo "Coverage report generated: coverage/coverage.html"
 
+build-e2e: ## Build binary for e2e tests
+	$(GOBUILD) -o e2e/$(BINARY_NAME)-e2e-test $(BUILD_DIR)
+
+test-e2e: build-e2e ## Run end-to-end tests
+	@echo "Running e2e tests..."
+	@cd e2e && $(GOTEST) . -v; \
+	EXIT_CODE=$$?; \
+	$(MAKE) -C .. clean-e2e; \
+	exit $$EXIT_CODE
+
+clean-e2e: ## Remove e2e test binary
+	rm -f e2e/$(BINARY_NAME)-e2e-test
+
 check-coverage: ## Run tests with coverage and enforce minimum threshold
 	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
 	@coverage_file=$$(mktemp); \
 	trap 'rm -f "$$coverage_file"' EXIT; \
-	$(GOTEST) ./... -coverprofile="$$coverage_file"; \
+	$(GOTEST) $$(go list ./... | grep -v /e2e) -coverprofile="$$coverage_file"; \
 	total=$$($(GOCMD) tool cover -func="$$coverage_file" | grep '^total' | awk '{print $$3}' | tr -d '%'); \
 	echo "Total coverage: $${total}%"; \
 	if ! awk "BEGIN { exit !($$total >= $(COVERAGE_THRESHOLD)) }"; then \

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,156 @@
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+const binaryName = "colref-e2e-test"
+
+func run(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	if _, err := os.Stat("./" + binaryName); err != nil {
+		t.Fatalf("e2e binary not found: %v — run 'make build-e2e' first", err)
+	}
+	cmd := exec.Command("./"+binaryName, args...)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func assertContains(t *testing.T, out []byte, want string) {
+	t.Helper()
+	if !bytes.Contains(out, []byte(want)) {
+		t.Errorf("expected output to contain %q\ngot:\n%s", want, out)
+	}
+}
+
+func assertNotContains(t *testing.T, out []byte, unwanted string) {
+	t.Helper()
+	if bytes.Contains(out, []byte(unwanted)) {
+		t.Errorf("expected output NOT to contain %q\ngot:\n%s", unwanted, out)
+	}
+}
+
+func TestE2E_Django(t *testing.T) {
+	fixture := "fixtures/django"
+
+	t.Run("RefsFound", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for User.email")
+		assertContains(t, out, "accounts/views.py")
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "name", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "No references found for User.name")
+		assertContains(t, out, "Verify manually before deleting.")
+	})
+
+	t.Run("UnknownModel", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "Invoice", "--field", "amount", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown model")
+		}
+		assertContains(t, out, `"Invoice" not found`)
+		assertContains(t, out, "Available models:")
+	})
+
+	t.Run("UnknownField", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "phone", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown field")
+		}
+		assertContains(t, out, `"phone" not found`)
+		assertContains(t, out, "Available fields:")
+	})
+}
+
+func TestE2E_Rails(t *testing.T) {
+	fixture := "fixtures/rails"
+
+	t.Run("RefsFound", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for User.email")
+		assertContains(t, out, "app/user.rb")
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "name", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "No references found for User.name")
+		assertContains(t, out, "Verify manually before deleting.")
+	})
+
+	t.Run("UnknownModel", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "rails", "--model", "Invoice", "--field", "amount", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown model")
+		}
+		assertContains(t, out, `"Invoice" not found`)
+	})
+
+	t.Run("UnknownField", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "phone", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown field")
+		}
+		assertContains(t, out, `"phone" not found`)
+	})
+
+	t.Run("NoSchemaFile", func(t *testing.T) {
+		dir := t.TempDir()
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", dir)
+		if err == nil {
+			t.Fatal("expected non-zero exit for missing schema.rb")
+		}
+		assertContains(t, out, "schema.rb")
+	})
+}
+
+func TestE2E_UnknownOrm(t *testing.T) {
+	out, err := run(t, "check", "--orm", "typeorm", "--model", "User", "--field", "email", "fixtures/django")
+	if err == nil {
+		t.Fatal("expected non-zero exit for unknown --orm")
+	}
+	assertContains(t, out, `unknown --orm "typeorm"`)
+	assertContains(t, out, "supported values are django, rails")
+}
+
+func TestE2E_MissingFlags(t *testing.T) {
+	t.Run("MissingOrm", func(t *testing.T) {
+		out, err := run(t, "check", "--model", "User", "--field", "email")
+		if err == nil {
+			t.Fatal("expected non-zero exit for missing --orm")
+		}
+		assertContains(t, out, "orm")
+	})
+
+	t.Run("MissingModel", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--field", "email")
+		if err == nil {
+			t.Fatal("expected non-zero exit for missing --model")
+		}
+		assertContains(t, out, "model")
+	})
+
+	t.Run("MissingField", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User")
+		if err == nil {
+			t.Fatal("expected non-zero exit for missing --field")
+		}
+		assertContains(t, out, "field")
+	})
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,6 +43,7 @@ func TestE2E_Django(t *testing.T) {
 		}
 		assertContains(t, out, "References found for User.email")
 		assertContains(t, out, "accounts/views.py")
+		assertNotContains(t, out, "No references found")
 	})
 
 	t.Run("NoRefs", func(t *testing.T) {
@@ -52,6 +53,7 @@ func TestE2E_Django(t *testing.T) {
 		}
 		assertContains(t, out, "No references found for User.name")
 		assertContains(t, out, "Verify manually before deleting.")
+		assertNotContains(t, out, "References found for")
 	})
 
 	t.Run("UnknownModel", func(t *testing.T) {

--- a/e2e/fixtures/django/accounts/models.py
+++ b/e2e/fixtures/django/accounts/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    name = models.CharField(max_length=100)

--- a/e2e/fixtures/django/accounts/views.py
+++ b/e2e/fixtures/django/accounts/views.py
@@ -1,0 +1,2 @@
+def send_notification(user):
+    return user.email

--- a/e2e/fixtures/django/blog/models.py
+++ b/e2e/fixtures/django/blog/models.py
@@ -1,0 +1,4 @@
+from django.db import models
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)

--- a/e2e/fixtures/django/blog/views.py
+++ b/e2e/fixtures/django/blog/views.py
@@ -1,0 +1,2 @@
+def show(post):
+    return post.title

--- a/e2e/fixtures/rails/app/user.rb
+++ b/e2e/fixtures/rails/app/user.rb
@@ -1,0 +1,5 @@
+class UserMailer
+  def welcome(user)
+    user.email
+  end
+end

--- a/e2e/fixtures/rails/db/schema.rb
+++ b/e2e/fixtures/rails/db/schema.rb
@@ -1,0 +1,10 @@
+ActiveRecord::Schema[7.0].define(version: 2024_01_01_000000) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+  end
+end


### PR DESCRIPTION
## Summary

- `e2e/e2e_test.go`: runs the built binary via `exec.Command` and asserts on combined output and exit code
- `e2e/fixtures/`: minimal Django and Rails project fixtures
- `Makefile`: adds `build-e2e`, `test-e2e`, `clean-e2e` targets; excludes `./e2e` from `check-coverage`

## Usage

```
make test-e2e
```

Builds the binary into `e2e/colref-e2e-test`, runs all e2e tests, then removes the binary.

## Test cases

- Django: refs found, no refs, unknown model, unknown field
- Rails: refs found, no refs, unknown model, unknown field, missing schema.rb
- Unknown `--orm` value
- Missing required flags (`--orm`, `--model`, `--field`)

Closes #53