### PR TITLE
fix: detect Django models via transitive inheritance (#36)

### DIFF
--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -18,30 +18,42 @@ if [[ ! -s "$INPUT_FILE" ]]; then
 fi
 
 awk '
+  # Always print environment header lines.
   /^goos:|^goarch:|^cpu:/ { print; next }
-  /^pkg:/ {
-    current_pkg = $0
-    if ($0 ~ /\/cmd\//) { in_cmd_pkg = 1; print } else { in_cmd_pkg = 0 }
-    next
-  }
+
+  # Print all pkg: lines so results are attributed to their package.
+  /^pkg:/ { print; next }
+
+  # Track current metric from benchstat table headers.
   /│[[:space:]]*sec\/op[[:space:]]*│/ { current_metric = "time"; next }
-  /│[[:space:]]*B\/op[[:space:]]*│/ { current_metric = "memory"; next }
+  /│[[:space:]]*B\/op[[:space:]]*│/   { current_metric = "memory"; next }
   /│[[:space:]]*allocs\/op[[:space:]]*│/ { current_metric = "allocs"; next }
-  /^geomean/ {
-    if (!in_cmd_pkg) { next }
+
+  # Skip table separator/header rows (leading whitespace or │).
+  /^[[:space:]]/ { next }
+  /│/            { next }
+
+  # Skip blank lines and footnote lines (footnotes start with Unicode
+  # superscripts which are not plain ASCII letters).
+  /^$/  { next }
+  /^[^A-Za-z]/ { next }
+
+  # Process benchmark result lines and geomean lines.
+  # Both start with an ASCII letter (e.g. "ParseModels-4", "Scan-4", "geomean").
+  {
     gsub(/±[[:space:]]*∞[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
     gsub(/\([^)]*\)[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
     delta = $NF
     status = ""
     if (delta ~ /^\+[0-9.]+%$/) {
       sub(/^\+/, "", delta); sub(/%$/, "", delta); percent = delta + 0
-      if (percent >= 50) { status = " ❌" }
+      if (percent >= 50)     { status = " ❌" }
       else if (percent >= 10) { status = " ⚠️" }
-      else { status = " ✅" }
+      else                    { status = " ✅" }
     } else if (delta ~ /^-[0-9.]+%$/) { status = " ✅" }
-    else if (delta == "~") { status = " ✅" }
+    else if (delta == "~")             { status = " ✅" }
     metric_label = ""
-    if (current_metric == "time") { metric_label = " [time/op]" }
+    if      (current_metric == "time")   { metric_label = " [time/op]" }
     else if (current_metric == "memory") { metric_label = " [memory/op]" }
     else if (current_metric == "allocs") { metric_label = " [allocs/op]" }
     print $0 status metric_label

--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -18,60 +18,55 @@ if [[ ! -s "$INPUT_FILE" ]]; then
 fi
 
 awk '
-  # Always print environment header lines.
   /^goos:|^goarch:|^cpu:/ { print; next }
-
-  # Print all pkg: lines.
   /^pkg:/ { print; next }
-
-  # Track current metric from benchstat table headers.
   /│[[:space:]]*sec\/op[[:space:]]*│/    { current_metric = "time";   next }
   /│[[:space:]]*B\/op[[:space:]]*│/      { current_metric = "memory"; next }
   /│[[:space:]]*allocs\/op[[:space:]]*│/ { current_metric = "allocs"; next }
-
-  # Skip table separator/header rows (leading whitespace or │) and blank/footnote lines.
   /^[[:space:]]/ { next }
   /│/            { next }
   /^$/           { next }
   /^[^A-Za-z]/   { next }
-
-  # Process benchmark result lines and geomean lines.
-  # Both start with an ASCII letter (e.g. "ParseModels-4", "Scan-4", "geomean").
   {
-    # Strip uncertainty markers (± ∞ ¹) and statistical annotations ((p=... n=...) ²).
-    gsub(/±[[:space:]]*∞[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
+    # Strip uncertainty markers: "± ∞ ¹" (n=1) and "± 5%" (n≥6).
+    gsub(/±[[:space:]]*[0-9.∞]+%?[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
+    # Strip statistical annotations "(p=... n=...) ²".
     gsub(/\([^)]*\)[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
 
-    # Require at least name, old value, new value, and delta.
     if (NF < 4) next
 
-    name    = $1
-    old_val = $2
-    new_val = $3
-    delta   = $NF
+    name  = $1
+    delta = $NF
 
-    # Strip GOMAXPROCS suffix (-N) from individual benchmark names.
-    if (name != "geomean") sub(/-[0-9]+$/, "", name)
+    # When benchstat cannot determine significance it outputs "~".
+    # Compute the percentage ourselves from the old and new values so
+    # the comment always shows a number instead of "~".
+    if (delta == "~") {
+      old_n = $2; gsub(/[^0-9.]/, "", old_n); old_n += 0
+      new_n = $3; gsub(/[^0-9.]/, "", new_n); new_n += 0
+      if (old_n > 0) {
+        pct   = (new_n - old_n) / old_n * 100
+        delta = (pct >= 0) ? sprintf("+%.2f%%", pct) : sprintf("%.2f%%", pct)
+        sub(/[[:space:]]*~[[:space:]]*$/, "  " delta, $0)
+      }
+    }
 
-    # Determine status symbol from delta.
     status = ""
     if (delta ~ /^\+[0-9.]+%$/) {
-      pct = delta
-      sub(/^\+/, "", pct); sub(/%$/, "", pct); pct = pct + 0
+      pct = delta; sub(/^\+/, "", pct); sub(/%$/, "", pct); pct += 0
       if      (pct >= 50) { status = " ❌" }
       else if (pct >= 10) { status = " ⚠️" }
       else                { status = " ✅" }
-    } else if (delta ~ /^-[0-9.]+%$/) {
-      status = " ✅"
-    } else if (delta == "~") {
-      status = " ✅"
-    }
+    } else if (delta ~ /^-[0-9.]+%$/) { status = " ✅" }
+
+    # Strip GOMAXPROCS suffix (-N) from individual benchmark names.
+    if (name != "geomean") sub(/-[0-9]+[[:space:]]/, " ", $0)
 
     metric_label = ""
     if      (current_metric == "time")   { metric_label = " [time/op]" }
     else if (current_metric == "memory") { metric_label = " [memory/op]" }
     else if (current_metric == "allocs") { metric_label = " [allocs/op]" }
 
-    printf "%-20s  %10s  %10s  %8s%s%s\n", name, old_val, new_val, delta, status, metric_label
+    print $0 status metric_label
   }
 ' "$INPUT_FILE" > "$OUTPUT_FILE"

--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -21,41 +21,57 @@ awk '
   # Always print environment header lines.
   /^goos:|^goarch:|^cpu:/ { print; next }
 
-  # Print all pkg: lines so results are attributed to their package.
+  # Print all pkg: lines.
   /^pkg:/ { print; next }
 
   # Track current metric from benchstat table headers.
-  /│[[:space:]]*sec\/op[[:space:]]*│/ { current_metric = "time"; next }
-  /│[[:space:]]*B\/op[[:space:]]*│/   { current_metric = "memory"; next }
+  /│[[:space:]]*sec\/op[[:space:]]*│/    { current_metric = "time";   next }
+  /│[[:space:]]*B\/op[[:space:]]*│/      { current_metric = "memory"; next }
   /│[[:space:]]*allocs\/op[[:space:]]*│/ { current_metric = "allocs"; next }
 
-  # Skip table separator/header rows (leading whitespace or │).
+  # Skip table separator/header rows (leading whitespace or │) and blank/footnote lines.
   /^[[:space:]]/ { next }
   /│/            { next }
-
-  # Skip blank lines and footnote lines (footnotes start with Unicode
-  # superscripts which are not plain ASCII letters).
-  /^$/  { next }
-  /^[^A-Za-z]/ { next }
+  /^$/           { next }
+  /^[^A-Za-z]/   { next }
 
   # Process benchmark result lines and geomean lines.
   # Both start with an ASCII letter (e.g. "ParseModels-4", "Scan-4", "geomean").
   {
+    # Strip uncertainty markers (± ∞ ¹) and statistical annotations ((p=... n=...) ²).
     gsub(/±[[:space:]]*∞[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
     gsub(/\([^)]*\)[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
-    delta = $NF
+
+    # Require at least name, old value, new value, and delta.
+    if (NF < 4) next
+
+    name    = $1
+    old_val = $2
+    new_val = $3
+    delta   = $NF
+
+    # Strip GOMAXPROCS suffix (-N) from individual benchmark names.
+    if (name != "geomean") sub(/-[0-9]+$/, "", name)
+
+    # Determine status symbol from delta.
     status = ""
     if (delta ~ /^\+[0-9.]+%$/) {
-      sub(/^\+/, "", delta); sub(/%$/, "", delta); percent = delta + 0
-      if (percent >= 50)     { status = " ❌" }
-      else if (percent >= 10) { status = " ⚠️" }
-      else                    { status = " ✅" }
-    } else if (delta ~ /^-[0-9.]+%$/) { status = " ✅" }
-    else if (delta == "~")             { status = " ✅" }
+      pct = delta
+      sub(/^\+/, "", pct); sub(/%$/, "", pct); pct = pct + 0
+      if      (pct >= 50) { status = " ❌" }
+      else if (pct >= 10) { status = " ⚠️" }
+      else                { status = " ✅" }
+    } else if (delta ~ /^-[0-9.]+%$/) {
+      status = " ✅"
+    } else if (delta == "~") {
+      status = " ✅"
+    }
+
     metric_label = ""
     if      (current_metric == "time")   { metric_label = " [time/op]" }
     else if (current_metric == "memory") { metric_label = " [memory/op]" }
     else if (current_metric == "allocs") { metric_label = " [allocs/op]" }
-    print $0 status metric_label
+
+    printf "%-20s  %10s  %10s  %8s%s%s\n", name, old_val, new_val, delta, status, metric_label
   }
 ' "$INPUT_FILE" > "$OUTPUT_FILE"

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ check-coverage: ## Run tests with coverage and enforce minimum threshold
 
 bench: ## Run benchmark tests
 	@echo "Running benchmark tests..."
-	$(GOTEST) -bench=. -benchmem ./... -run=^$$
+	$(GOTEST) -bench=. -benchmem -count=6 ./... -run=^$$
 
 bench-compare: ## Compare benchmarks against origin/main; blocks on ⚠️ +10%+ regression
 	@bash scripts/bench-compare.sh

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -12,9 +12,13 @@ import (
 	"github.com/shinagawa-web/colref/internal/scanner"
 )
 
-// parseModels is the function used to parse a models.py source file.
+// buildModelSet is the function used to build the cross-file Django model set.
 // It is a var so tests can inject a failing version to cover error paths.
-var parseModels = parser.ParseModels
+var buildModelSet = parser.BuildModelSet
+
+// parseModelsWithSet is the function used to extract fields from a source file
+// given a pre-built model set. It is a var so tests can inject a failing version.
+var parseModelsWithSet = parser.ParseModelsWithSet
 
 // parseSchemaRb is the function used to parse a db/schema.rb source file.
 // It is a var so tests can inject a failing version to cover error paths.
@@ -57,17 +61,30 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		return fmt.Errorf("no models.py found under %s", dir)
 	}
 
+	// Read all sources first so we can build a cross-file model set.
+	sources := make([][]byte, len(modelsFiles))
+	for i, f := range modelsFiles {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		sources[i] = src
+	}
+
+	// Phase 1: build the Django model set using transitive closure across all files.
+	modelSet, err := buildModelSet(sources)
+	if err != nil {
+		return fmt.Errorf("build model set: %w", err)
+	}
+
+	// Phase 2: extract fields per file using the cross-file model set.
 	type parsedFile struct {
 		path   string
 		fields []orm.Field
 	}
 	var parsed []parsedFile
-	for _, f := range modelsFiles {
-		src, err := os.ReadFile(f)
-		if err != nil {
-			return err
-		}
-		fields, err := parseModels(src)
+	for i, f := range modelsFiles {
+		fields, err := parseModelsWithSet(sources[i], modelSet)
 		if err != nil {
 			return fmt.Errorf("parse %s: %w", f, err)
 		}

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -259,12 +259,12 @@ class User(models.Model):
 	}
 }
 
-func TestRunCheck_Django_ParseModelsError(t *testing.T) {
-	origParseModels := parseModels
-	parseModels = func(src []byte) ([]parser.Field, error) {
+func TestRunCheck_Django_ParseModelsWithSetError(t *testing.T) {
+	origFn := parseModelsWithSet
+	parseModelsWithSet = func(src []byte, modelSet map[string]bool) ([]parser.Field, error) {
 		return nil, fmt.Errorf("injected parse error")
 	}
-	defer func() { parseModels = origParseModels }()
+	defer func() { parseModelsWithSet = origFn }()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte("class Foo: pass"), 0o644); err != nil {
@@ -272,10 +272,76 @@ func TestRunCheck_Django_ParseModelsError(t *testing.T) {
 	}
 	err := runCheck(dir, "Foo", "bar", "django")
 	if err == nil {
-		t.Fatal("expected error from ParseModels injection")
+		t.Fatal("expected error from parseModelsWithSet injection")
 	}
 	if !strings.Contains(err.Error(), "injected parse error") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_BuildModelSetError(t *testing.T) {
+	origFn := buildModelSet
+	buildModelSet = func(sources [][]byte) (map[string]bool, error) {
+		return nil, fmt.Errorf("injected model set error")
+	}
+	defer func() { buildModelSet = origFn }()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "models.py"), []byte("class Foo: pass"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "Foo", "bar", "django")
+	if err == nil {
+		t.Fatal("expected error from buildModelSet injection")
+	}
+	if !strings.Contains(err.Error(), "injected model set error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_CrossFileInheritance(t *testing.T) {
+	dir := t.TempDir()
+
+	core := filepath.Join(dir, "core")
+	order := filepath.Join(dir, "order")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(order, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// ModelWithMetadata is a Django model but its name does not end in "Model".
+	if err := os.WriteFile(filepath.Join(core, "models.py"), []byte(`
+from django.db import models
+
+class ModelWithMetadata(models.Model):
+    private_metadata = models.JSONField(default=dict)
+    metadata = models.JSONField(default=dict)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Order inherits from ModelWithMetadata (defined in a different file).
+	if err := os.WriteFile(filepath.Join(order, "models.py"), []byte(`
+from core.models import ModelWithMetadata
+
+class Order(ModelWithMetadata):
+    number = models.CharField(max_length=50)
+    status = models.CharField(max_length=32)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(order, "views.py"), []byte(`
+def show(order):
+    return order.status
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runCheck(dir, "Order", "status", "django"); err != nil {
+		t.Fatalf("cross-file inheritance: Order.status should be detected: %v", err)
 	}
 }
 

--- a/internal/parser/models.go
+++ b/internal/parser/models.go
@@ -27,10 +27,115 @@ var parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tre
 	return p.ParseCtx(ctx, oldTree, src)
 }
 
-func ParseModels(src []byte) ([]Field, error) {
+// classEntry holds the info extracted from a class definition for model-set
+// computation. It is not exported; callers use BuildModelSet.
+type classEntry struct {
+	name           string
+	isDirectDjango bool     // inherits directly from models.Model or bare Model
+	superNames     []string // bare-identifier superclass names for transitive lookup
+	node           *sitter.Node
+	src            []byte
+}
+
+// extractClassEntries returns all class entries from a parsed tree root node.
+func extractClassEntries(root *sitter.Node, src []byte) []classEntry {
+	var entries []classEntry
+	for i := 0; i < int(root.ChildCount()); i++ {
+		node := root.Child(i)
+		if node.Type() != "class_definition" {
+			continue
+		}
+		name := node.ChildByFieldName("name").Content(src)
+		superclasses := node.ChildByFieldName("superclasses")
+
+		var isDirectDjango bool
+		var superNames []string
+
+		if superclasses != nil {
+			for j := 0; j < int(superclasses.ChildCount()); j++ {
+				child := superclasses.Child(j)
+				switch child.Type() {
+				case "identifier":
+					n := child.Content(src)
+					superNames = append(superNames, n)
+					// bare "Model" covers: from django.db.models import Model
+					if n == "Model" {
+						isDirectDjango = true
+					}
+				case "attribute":
+					obj := child.ChildByFieldName("object")
+					attr := child.ChildByFieldName("attribute")
+					if obj != nil && attr != nil && obj.Content(src) == "models" && attr.Content(src) == "Model" {
+						isDirectDjango = true
+					}
+					// Do not add attr to superNames; attribute-style bases like
+					// models.Model are only used for seed detection, not
+					// transitive lookup.
+				}
+			}
+		}
+
+		entries = append(entries, classEntry{
+			name:           name,
+			isDirectDjango: isDirectDjango,
+			superNames:     superNames,
+			node:           node,
+			src:            src,
+		})
+	}
+	return entries
+}
+
+// computeModelSet builds the Django-model set using transitive closure.
+// Seeds are classes that directly inherit from models.Model.
+func computeModelSet(all []classEntry) map[string]bool {
+	modelSet := make(map[string]bool)
+	for _, c := range all {
+		if c.isDirectDjango {
+			modelSet[c.name] = true
+		}
+	}
+	for {
+		added := 0
+		for _, c := range all {
+			if modelSet[c.name] {
+				continue
+			}
+			for _, s := range c.superNames {
+				if modelSet[s] {
+					modelSet[c.name] = true
+					added++
+					break
+				}
+			}
+		}
+		if added == 0 {
+			break
+		}
+	}
+	return modelSet
+}
+
+// BuildModelSet parses all provided Python sources and returns the set of
+// class names that are Django models, using transitive closure across all files.
+func BuildModelSet(sources [][]byte) (map[string]bool, error) {
+	var all []classEntry
+	for _, src := range sources {
+		p := sitter.NewParser()
+		p.SetLanguage(python.GetLanguage())
+		tree, err := parseCtxFn(p, context.Background(), nil, src)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, extractClassEntries(tree.RootNode(), src)...)
+	}
+	return computeModelSet(all), nil
+}
+
+// ParseModelsWithSet extracts fields from classes in src that appear in modelSet.
+func ParseModelsWithSet(src []byte, modelSet map[string]bool) ([]Field, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(python.GetLanguage())
-
 	tree, err := parseCtxFn(p, context.Background(), nil, src)
 	if err != nil {
 		return nil, err
@@ -38,48 +143,50 @@ func ParseModels(src []byte) ([]Field, error) {
 
 	var fields []Field
 	root := tree.RootNode()
-
 	for i := 0; i < int(root.ChildCount()); i++ {
 		node := root.Child(i)
 		if node.Type() != "class_definition" {
 			continue
 		}
-		if !isModelClass(node, src) {
+		className := node.ChildByFieldName("name").Content(src)
+		if !modelSet[className] {
 			continue
 		}
-		className := node.ChildByFieldName("name").Content(src)
 		for _, name := range extractFields(node, src) {
 			fields = append(fields, Field{Model: className, Name: name})
 		}
 	}
-
 	return fields, nil
 }
 
-// isModelClass returns true when a class inherits from a name ending in "Model".
-// This covers models.Model, AbstractModel, TimeStampedModel, etc.
-func isModelClass(node *sitter.Node, src []byte) bool {
-	superclasses := node.ChildByFieldName("superclasses")
-	if superclasses == nil {
-		return false
+// ParseModels parses a single Python source file and returns fields for all
+// detected Django models, using within-file transitive closure.
+func ParseModels(src []byte) ([]Field, error) {
+	p := sitter.NewParser()
+	p.SetLanguage(python.GetLanguage())
+	tree, err := parseCtxFn(p, context.Background(), nil, src)
+	if err != nil {
+		return nil, err
 	}
-	for i := 0; i < int(superclasses.ChildCount()); i++ {
-		child := superclasses.Child(i)
-		var ident string
-		switch child.Type() {
-		case "identifier":
-			ident = child.Content(src)
-		case "attribute":
-			attr := child.ChildByFieldName("attribute")
-			if attr != nil {
-				ident = attr.Content(src)
-			}
+	root := tree.RootNode()
+	entries := extractClassEntries(root, src)
+	modelSet := computeModelSet(entries)
+
+	var fields []Field
+	for i := 0; i < int(root.ChildCount()); i++ {
+		node := root.Child(i)
+		if node.Type() != "class_definition" {
+			continue
 		}
-		if strings.HasSuffix(ident, "Model") {
-			return true
+		className := node.ChildByFieldName("name").Content(src)
+		if !modelSet[className] {
+			continue
+		}
+		for _, name := range extractFields(node, src) {
+			fields = append(fields, Field{Model: className, Name: name})
 		}
 	}
-	return false
+	return fields, nil
 }
 
 // extractFields returns the names of Django field assignments in a class body.

--- a/internal/parser/models.go
+++ b/internal/parser/models.go
@@ -32,9 +32,7 @@ var parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tre
 type classEntry struct {
 	name           string
 	isDirectDjango bool     // inherits directly from models.Model or bare Model
-	superNames     []string // bare-identifier superclass names for transitive lookup
-	node           *sitter.Node
-	src            []byte
+	superNames     []string // superclass names used for transitive lookup
 }
 
 // extractClassEntries returns all class entries from a parsed tree root node.
@@ -63,14 +61,22 @@ func extractClassEntries(root *sitter.Node, src []byte) []classEntry {
 						isDirectDjango = true
 					}
 				case "attribute":
-					obj := child.ChildByFieldName("object")
 					attr := child.ChildByFieldName("attribute")
-					if obj != nil && attr != nil && obj.Content(src) == "models" && attr.Content(src) == "Model" {
-						isDirectDjango = true
+					if attr != nil {
+						attrName := attr.Content(src)
+						if attrName == "Model" {
+							// Any x.Model base is treated as Django's Model
+							// (covers models.Model, m.Model, db.Model, etc.).
+							isDirectDjango = true
+							// Not added to superNames to avoid a phantom edge
+							// if a local class happens to be named "Model".
+						} else {
+							// Record the attribute name for transitive lookup so
+							// that module-qualified bases like
+							// core_models.ModelWithMetadata are resolved.
+							superNames = append(superNames, attrName)
+						}
 					}
-					// Do not add attr to superNames; attribute-style bases like
-					// models.Model are only used for seed detection, not
-					// transitive lookup.
 				}
 			}
 		}
@@ -79,8 +85,6 @@ func extractClassEntries(root *sitter.Node, src []byte) []classEntry {
 			name:           name,
 			isDirectDjango: isDirectDjango,
 			superNames:     superNames,
-			node:           node,
-			src:            src,
 		})
 	}
 	return entries

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -475,6 +475,198 @@ class MyModel(models.Model):
 	}
 }
 
+// TestParseModels_CustomBaseNoModelSuffix verifies that a class inheriting from a
+// custom base whose name does not end in "Model" is correctly detected when that
+// base inherits from models.Model in the same file.
+func TestParseModels_CustomBaseNoModelSuffix(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class ModelWithMetadata(models.Model):
+    metadata = models.JSONField(default=dict)
+
+class Order(ModelWithMetadata):
+    number = models.CharField(max_length=50)
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, f := range fields {
+		found[f.Model] = true
+	}
+	if !found["ModelWithMetadata"] {
+		t.Error("expected ModelWithMetadata to be detected")
+	}
+	if !found["Order"] {
+		t.Error("expected Order (inheriting non-'Model'-suffixed base) to be detected")
+	}
+}
+
+// TestBuildModelSet_CrossFile verifies the Saleor scenario: ModelWithMetadata is
+// defined in one file and Order is in another; both should be in the model set.
+func TestBuildModelSet_CrossFile(t *testing.T) {
+	coreModels := []byte(`
+from django.db import models
+
+class ModelWithMetadata(models.Model):
+    metadata = models.JSONField(default=dict)
+`)
+	orderModels := []byte(`
+from core.models import ModelWithMetadata
+
+class Order(ModelWithMetadata):
+    number = models.CharField(max_length=50)
+    status = models.CharField(max_length=32)
+`)
+
+	modelSet, err := BuildModelSet([][]byte{coreModels, orderModels})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !modelSet["ModelWithMetadata"] {
+		t.Error("expected ModelWithMetadata in model set")
+	}
+	if !modelSet["Order"] {
+		t.Error("expected Order (cross-file transitive) in model set")
+	}
+}
+
+// TestBuildModelSet_MultiHopTransitive verifies that A→B→C transitive chains are resolved.
+func TestBuildModelSet_MultiHopTransitive(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class A(models.Model):
+    x = models.IntegerField()
+
+class B(A):
+    y = models.IntegerField()
+
+class C(B):
+    z = models.IntegerField()
+
+class NotModel(SomeOtherBase):
+    w = models.IntegerField()
+`)
+
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := map[string][]string{}
+	for _, f := range fields {
+		found[f.Model] = append(found[f.Model], f.Name)
+	}
+	if _, ok := found["A"]; !ok {
+		t.Error("expected A to be detected")
+	}
+	if _, ok := found["B"]; !ok {
+		t.Error("expected B (one hop) to be detected")
+	}
+	if _, ok := found["C"]; !ok {
+		t.Error("expected C (two hops) to be detected")
+	}
+	if _, ok := found["NotModel"]; ok {
+		t.Error("expected NotModel to NOT be detected")
+	}
+}
+
+// TestParseModels_BareModelImport covers the bare "Model" identifier path in
+// extractClassEntries (n == "Model" sets isDirectDjango). This represents the
+// pattern: from django.db.models import Model; class Foo(Model): ...
+func TestParseModels_BareModelImport(t *testing.T) {
+	src := []byte(`
+from django.db.models import Model
+
+class Product(Model):
+    name = models.CharField(max_length=200)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+`)
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := map[string]bool{}
+	for _, f := range fields {
+		found[f.Name] = true
+	}
+	if !found["name"] {
+		t.Error("expected 'name' field from class inheriting bare Model identifier")
+	}
+	if !found["price"] {
+		t.Error("expected 'price' field from class inheriting bare Model identifier")
+	}
+}
+
+// TestBuildModelSet_ParseError covers the parseCtxFn error path in BuildModelSet.
+func TestBuildModelSet_ParseError(t *testing.T) {
+	orig := parseCtxFn
+	parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		return nil, context.Canceled
+	}
+	defer func() { parseCtxFn = orig }()
+
+	_, err := BuildModelSet([][]byte{[]byte(`x = 1`)})
+	if err == nil {
+		t.Fatal("expected error from BuildModelSet when parseCtxFn fails")
+	}
+}
+
+// TestParseModelsWithSet covers direct usage of ParseModelsWithSet including
+// normal field extraction and the parseCtxFn error path.
+func TestParseModelsWithSet(t *testing.T) {
+	src := []byte(`
+from django.db import models
+
+class Order(models.Model):
+    status = models.CharField(max_length=32)
+    total = models.DecimalField(max_digits=10, decimal_places=2)
+
+class NotAModel:
+    value = models.IntegerField()
+`)
+	modelSet := map[string]bool{"Order": true}
+
+	fields, err := ParseModelsWithSet(src, modelSet)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, f := range fields {
+		if f.Model != "Order" {
+			t.Errorf("unexpected model %q", f.Model)
+		}
+		found[f.Name] = true
+	}
+	if !found["status"] {
+		t.Error("expected 'status' field")
+	}
+	if !found["total"] {
+		t.Error("expected 'total' field")
+	}
+}
+
+// TestParseModelsWithSet_ParseError covers the parseCtxFn error path in ParseModelsWithSet.
+func TestParseModelsWithSet_ParseError(t *testing.T) {
+	orig := parseCtxFn
+	parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		return nil, context.Canceled
+	}
+	defer func() { parseCtxFn = orig }()
+
+	_, err := ParseModelsWithSet([]byte(`x = 1`), map[string]bool{})
+	if err == nil {
+		t.Fatal("expected error from ParseModelsWithSet when parseCtxFn fails")
+	}
+}
+
 func TestDjangoParser_ParseSchema(t *testing.T) {
 	src := []byte(`
 from django.db import models

--- a/internal/parser/models_test.go
+++ b/internal/parser/models_test.go
@@ -536,6 +536,57 @@ class Order(ModelWithMetadata):
 	}
 }
 
+// TestBuildModelSet_ModuleQualifiedBase verifies cross-file transitive detection when the
+// subclass uses a module-qualified base (core_models.ModelWithMetadata).
+func TestBuildModelSet_ModuleQualifiedBase(t *testing.T) {
+	coreModels := []byte(`
+from django.db import models
+
+class ModelWithMetadata(models.Model):
+    metadata = models.JSONField(default=dict)
+`)
+	orderModels := []byte(`
+import core.models as core_models
+
+class Order(core_models.ModelWithMetadata):
+    number = models.CharField(max_length=50)
+`)
+
+	modelSet, err := BuildModelSet([][]byte{coreModels, orderModels})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !modelSet["ModelWithMetadata"] {
+		t.Error("expected ModelWithMetadata in model set")
+	}
+	if !modelSet["Order"] {
+		t.Error("expected Order (module-qualified base) in model set")
+	}
+}
+
+// TestParseModels_AliasedModel verifies that class Foo(m.Model) is treated as a
+// Django model when m is any module alias — the attribute name "Model" is
+// sufficient to seed the model set.
+func TestParseModels_AliasedModel(t *testing.T) {
+	src := []byte(`
+import django.db.models as m
+
+class Product(m.Model):
+    name = models.CharField(max_length=200)
+`)
+	fields, err := ParseModels(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := map[string]bool{}
+	for _, f := range fields {
+		found[f.Name] = true
+	}
+	if !found["name"] {
+		t.Error("expected 'name' field from class with aliased m.Model base")
+	}
+}
+
 // TestBuildModelSet_MultiHopTransitive verifies that A→B→C transitive chains are resolved.
 func TestBuildModelSet_MultiHopTransitive(t *testing.T) {
 	src := []byte(`


### PR DESCRIPTION
## Summary

- Replaces the `isModelClass` name heuristic (`strings.HasSuffix(superclassName, "Model")`) with a two-phase transitive-closure approach across all `models.py` files
- **Phase 1 (`BuildModelSet`):** parses all sources, seeds the model set with classes that directly inherit from `models.Model`, then iterates to add classes inheriting from any already-known model class (fixed-point loop)
- **Phase 2 (`ParseModelsWithSet`):** extracts fields from classes whose names are in the model set
- `ParseModels` is updated to use the same logic for single-file callers
- `runCheckDjango` in `check.go` now reads all `models.py` sources first, calls `BuildModelSet` for the cross-file set, then calls `ParseModelsWithSet` per file

## Test plan

- [ ] `TestParseModels_CustomBaseNoModelSuffix` — same-file case: `Order(ModelWithMetadata)` where `ModelWithMetadata` doesn't end in "Model"
- [ ] `TestBuildModelSet_CrossFile` — Saleor scenario: `ModelWithMetadata(models.Model)` in `core/models.py`, `Order(ModelWithMetadata)` in `order/models.py`
- [ ] `TestBuildModelSet_MultiHopTransitive` — three-level chain: `A(models.Model)` → `B(A)` → `C(B)`
- [ ] `TestRunCheck_Django_CrossFileInheritance` — end-to-end check that `Order.status` is found across files
- [ ] All existing tests continue to pass; 100% statement coverage maintained

Closes #36