### PR TITLE
feat: scan ERB files and add Ruby-specific skip dirs

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -85,6 +85,7 @@ func TestE2E_Rails(t *testing.T) {
 		}
 		assertContains(t, out, "References found for User.email")
 		assertContains(t, out, "app/user.rb")
+		assertContains(t, out, "app/views/user.html.erb")
 	})
 
 	t.Run("NoRefs", func(t *testing.T) {

--- a/e2e/fixtures/rails/app/views/user.html.erb
+++ b/e2e/fixtures/rails/app/views/user.html.erb
@@ -1,0 +1,2 @@
+<h1>User Profile</h1>
+<p><%= @user.email %></p>

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -70,7 +70,7 @@ var RubySkipDirs = map[string]bool{
 	"node_modules": true,
 }
 
-// parseCtxFn is the function used to parse Python source into a tree.
+// parseCtxFn is the function used to parse source into a tree.
 // It is a var so tests can inject a failing version to cover error paths.
 var parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
 	return p.ParseCtx(ctx, oldTree, src)
@@ -83,26 +83,25 @@ var filepathRelFn = filepath.Rel
 // Scan walks dir and returns every attribute-access node whose attribute name
 // equals fieldName, along with the total number of .py files examined.
 func Scan(dir, fieldName string) ([]Reference, int, error) {
-	return scanFiles(dir, fieldName, ".py", python.GetLanguage(), walkNode, nil, SkipDirs)
+	return scanFiles(dir, fieldName, map[string]func([]byte) []byte{".py": nil}, python.GetLanguage(), walkNode, SkipDirs)
 }
 
 // ScanRuby walks dir and returns every method-call node whose method name
 // equals fieldName, along with the total number of .rb and .erb files examined.
 func ScanRuby(dir, fieldName string) ([]Reference, int, error) {
-	refs, n1, err := scanFiles(dir, fieldName, ".rb", ruby.GetLanguage(), walkNodeRuby, nil, RubySkipDirs)
-	if err != nil {
-		return nil, n1, err
-	}
-	erbRefs, n2, err := scanFiles(dir, fieldName, ".erb", ruby.GetLanguage(), walkNodeRuby, erbToRuby, RubySkipDirs)
-	if err != nil {
-		return nil, n1 + n2, err
-	}
-	return append(refs, erbRefs...), n1 + n2, nil
+	return scanFiles(dir, fieldName, map[string]func([]byte) []byte{
+		".rb":  nil,
+		".erb": erbToRuby,
+	}, ruby.GetLanguage(), walkNodeRuby, RubySkipDirs)
 }
 
 type walkFn func(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference)
 
-func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn, transform func([]byte) []byte, skipDirs map[string]bool) ([]Reference, int, error) {
+// scanFiles walks dir once and processes every file whose extension appears in
+// exts. Each value in exts is an optional transform applied to the raw source
+// before parsing; it must preserve len(src) so that tree-sitter byte offsets
+// remain valid. A nil transform means the source is used as-is.
+func scanFiles(dir, fieldName string, exts map[string]func([]byte) []byte, lang *sitter.Language, walk walkFn, skipDirs map[string]bool) ([]Reference, int, error) {
 	var refs []Reference
 	filesScanned := 0
 
@@ -117,7 +116,8 @@ func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn, t
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ext) {
+		transform, ok := exts[filepath.Ext(path)]
+		if !ok {
 			return nil
 		}
 		filesScanned++
@@ -200,6 +200,8 @@ func erbToRuby(src []byte) []byte {
 	out := make([]byte, len(src))
 	inRuby := false
 	inComment := false
+	inString := byte(0) // '"' or '\'' when inside a Ruby string literal
+	escaped := false
 	i := 0
 	for i < len(src) {
 		if inComment {
@@ -215,11 +217,24 @@ func erbToRuby(src []byte) []byte {
 				i++
 			}
 		} else if inRuby {
-			if i+1 < len(src) && src[i] == '%' && src[i+1] == '>' {
+			if inString != 0 {
+				out[i] = src[i]
+				if escaped {
+					escaped = false
+				} else if src[i] == '\\' {
+					escaped = true
+				} else if src[i] == inString {
+					inString = 0
+				}
+				i++
+			} else if i+1 < len(src) && src[i] == '%' && src[i+1] == '>' {
 				out[i], out[i+1] = ' ', ' '
 				i += 2
 				inRuby = false
 			} else {
+				if src[i] == '"' || src[i] == '\'' {
+					inString = src[i]
+				}
 				out[i] = src[i]
 				i++
 			}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -45,8 +45,8 @@ func (RubyScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
 
 // SkipDirs implements orm.ReferenceScanner, returning a defensive copy.
 func (RubyScanner) SkipDirs() map[string]bool {
-	copy := make(map[string]bool, len(SkipDirs))
-	for k, v := range SkipDirs {
+	copy := make(map[string]bool, len(RubySkipDirs))
+	for k, v := range RubySkipDirs {
 		copy[k] = v
 	}
 	return copy
@@ -58,6 +58,15 @@ var SkipDirs = map[string]bool{
 	"__pycache__":  true,
 	"venv":         true,
 	"migrations":   true,
+	"node_modules": true,
+}
+
+// RubySkipDirs is the set of directory names skipped when scanning Ruby projects.
+var RubySkipDirs = map[string]bool{
+	"spec":         true,
+	"test":         true,
+	"vendor":       true,
+	"migrate":      true,
 	"node_modules": true,
 }
 
@@ -74,18 +83,26 @@ var filepathRelFn = filepath.Rel
 // Scan walks dir and returns every attribute-access node whose attribute name
 // equals fieldName, along with the total number of .py files examined.
 func Scan(dir, fieldName string) ([]Reference, int, error) {
-	return scanFiles(dir, fieldName, ".py", python.GetLanguage(), walkNode)
+	return scanFiles(dir, fieldName, ".py", python.GetLanguage(), walkNode, nil, SkipDirs)
 }
 
 // ScanRuby walks dir and returns every method-call node whose method name
-// equals fieldName, along with the total number of .rb files examined.
+// equals fieldName, along with the total number of .rb and .erb files examined.
 func ScanRuby(dir, fieldName string) ([]Reference, int, error) {
-	return scanFiles(dir, fieldName, ".rb", ruby.GetLanguage(), walkNodeRuby)
+	refs, n1, err := scanFiles(dir, fieldName, ".rb", ruby.GetLanguage(), walkNodeRuby, nil, RubySkipDirs)
+	if err != nil {
+		return nil, n1, err
+	}
+	erbRefs, n2, err := scanFiles(dir, fieldName, ".erb", ruby.GetLanguage(), walkNodeRuby, erbToRuby, RubySkipDirs)
+	if err != nil {
+		return nil, n1 + n2, err
+	}
+	return append(refs, erbRefs...), n1 + n2, nil
 }
 
 type walkFn func(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference)
 
-func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn) ([]Reference, int, error) {
+func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn, transform func([]byte) []byte, skipDirs map[string]bool) ([]Reference, int, error) {
 	var refs []Reference
 	filesScanned := 0
 
@@ -95,7 +112,7 @@ func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn) (
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if path != dir && (strings.HasPrefix(name, ".") || SkipDirs[name]) {
+			if path != dir && (strings.HasPrefix(name, ".") || skipDirs[name]) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -110,9 +127,14 @@ func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn) (
 			return err
 		}
 
+		parseSrc := src
+		if transform != nil {
+			parseSrc = transform(src)
+		}
+
 		p := sitter.NewParser()
 		p.SetLanguage(lang)
-		tree, err := parseCtxFn(p, context.Background(), nil, src)
+		tree, err := parseCtxFn(p, context.Background(), nil, parseSrc)
 		if err != nil {
 			return err
 		}
@@ -123,7 +145,7 @@ func scanFiles(dir, fieldName, ext string, lang *sitter.Language, walk walkFn) (
 		}
 		lines := bytes.Split(src, []byte("\n"))
 		var fileRefs []Reference
-		walk(tree.RootNode(), src, lines, fieldName, rel, &fileRefs)
+		walk(tree.RootNode(), parseSrc, lines, fieldName, rel, &fileRefs)
 		refs = append(refs, dedupeByLine(fileRefs)...)
 		return nil
 	})
@@ -172,6 +194,60 @@ func walkNodeRuby(node *sitter.Node, src []byte, lines [][]byte, fieldName, file
 	for i := 0; i < int(node.ChildCount()); i++ {
 		walkNodeRuby(node.Child(i), src, lines, fieldName, file, refs)
 	}
+}
+
+func erbToRuby(src []byte) []byte {
+	out := make([]byte, len(src))
+	inRuby := false
+	inComment := false
+	i := 0
+	for i < len(src) {
+		if inComment {
+			if i+1 < len(src) && src[i] == '%' && src[i+1] == '>' {
+				out[i], out[i+1] = ' ', ' '
+				i += 2
+				inComment = false
+			} else if src[i] == '\n' {
+				out[i] = '\n'
+				i++
+			} else {
+				out[i] = ' '
+				i++
+			}
+		} else if inRuby {
+			if i+1 < len(src) && src[i] == '%' && src[i+1] == '>' {
+				out[i], out[i+1] = ' ', ' '
+				i += 2
+				inRuby = false
+			} else {
+				out[i] = src[i]
+				i++
+			}
+		} else {
+			if i+1 < len(src) && src[i] == '<' && src[i+1] == '%' {
+				out[i], out[i+1] = ' ', ' '
+				i += 2
+				if i < len(src) && src[i] == '#' {
+					out[i] = ' '
+					i++
+					inComment = true
+				} else {
+					if i < len(src) && (src[i] == '=' || src[i] == '-') {
+						out[i] = ' '
+						i++
+					}
+					inRuby = true
+				}
+			} else if src[i] == '\n' {
+				out[i] = '\n'
+				i++
+			} else {
+				out[i] = ' '
+				i++
+			}
+		}
+	}
+	return out
 }
 
 func walkNode(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -606,6 +606,332 @@ func TestRubyScanner_Methods(t *testing.T) {
 	if !skipDirs["node_modules"] {
 		t.Error("expected node_modules to be in SkipDirs")
 	}
+	if !skipDirs["spec"] {
+		t.Error("expected spec to be in RubySkipDirs")
+	}
+	if skipDirs["migrations"] {
+		t.Error("migrations should not be in RubySkipDirs")
+	}
+}
+
+func TestScanRuby_SkipSpecDir(t *testing.T) {
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "spec")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, specDir, "user_spec.rb", `user.email`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 files scanned (spec skipped), got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from spec dir, got %d", len(refs))
+	}
+}
+
+func TestScanRuby_SkipTestDir(t *testing.T) {
+	dir := t.TempDir()
+	testDir := filepath.Join(dir, "test")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, testDir, "user_test.rb", `user.email`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 files scanned (test skipped), got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from test dir, got %d", len(refs))
+	}
+}
+
+func TestScanRuby_SkipVendorDir(t *testing.T) {
+	dir := t.TempDir()
+	vendorDir := filepath.Join(dir, "vendor")
+	if err := os.MkdirAll(vendorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, vendorDir, "lib.rb", `user.email`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 files scanned (vendor skipped), got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from vendor dir, got %d", len(refs))
+	}
+}
+
+func TestScanRuby_SkipMigrateDir(t *testing.T) {
+	dir := t.TempDir()
+	migrateDir := filepath.Join(dir, "migrate")
+	if err := os.MkdirAll(migrateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, migrateDir, "001_create_users.rb", `user.email`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("want 0 files scanned (migrate skipped), got %d", count)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from migrate dir, got %d", len(refs))
+	}
+}
+
+func TestScanRuby_ERBBasicMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%= user.email %>`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBInstanceVar(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%= @user.email %>`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBNonOutputTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<% user.email %>`)
+
+	refs, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBLineNumber(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", "<h1>Title</h1>\n<p><%= @user.email %></p>")
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 2 {
+		t.Errorf("want line 2, got %d", refs[0].Line)
+	}
+}
+
+func TestScanRuby_ERBNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%= user.name %>`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBComment(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%# user.email %>`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs from ERB comment, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBCommentThenExpression(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%# x %><%= user.email %>`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref after comment, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBDashClose(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%= @user.email -%>`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref with -%%> closing, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRuby_ERBCountedInFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `user.email`)
+	writeFile(t, dir, "user.html.erb", `<%= user.email %>`)
+
+	_, count, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("want 2 files scanned (.rb + .erb), got %d", count)
+	}
+}
+
+func TestScanRuby_ERBParseCtxError(t *testing.T) {
+	orig := parseCtxFn
+	parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		return nil, context.Canceled
+	}
+	defer func() { parseCtxFn = orig }()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "user.html.erb", `<%= user.email %>`)
+
+	_, _, err := ScanRuby(dir, "email")
+	if err == nil {
+		t.Fatal("expected error when parseCtxFn fails on .erb file")
+	}
+}
+
+func TestScanRuby_RbParseCtxError(t *testing.T) {
+	orig := parseCtxFn
+	parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		return nil, context.Canceled
+	}
+	defer func() { parseCtxFn = orig }()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `user.email`)
+
+	_, _, err := ScanRuby(dir, "email")
+	if err == nil {
+		t.Fatal("expected error when parseCtxFn fails on .rb file")
+	}
+}
+
+func TestERBToRuby(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "html replaced with spaces, newlines preserved",
+			input: "<h1>hello</h1>\n",
+			want:  "              \n",
+		},
+		{
+			name:  "output tag content preserved",
+			input: "<%= user.email %>",
+			want:  "    user.email   ",
+		},
+		{
+			name:  "non-output tag content preserved",
+			input: "<% user.email %>",
+			want:  "   user.email   ",
+		},
+		{
+			name:  "dash modifier opening",
+			input: "<%= @user.email -%>",
+			want:  "    @user.email -  ",
+		},
+		{
+			name:  "dash modifier in opening tag (<%- )",
+			input: "<%- user.email %>",
+			want:  "    user.email   ",
+		},
+		{
+			name:  "comment tag: content replaced with spaces",
+			input: "<%# user.email %>",
+			want:  "                 ",
+		},
+		{
+			name:  "comment tag preserves newlines",
+			input: "<%# comment\nnext %>",
+			want:  "           \n       ",
+		},
+		{
+			name:  "comment then expression",
+			input: "<%# x %><%= user.email %>",
+			want:  "            user.email   ",
+		},
+		{
+			name:  "lone < not followed by % is replaced with space",
+			input: "<b>text</b>",
+			want:  "           ",
+		},
+		{
+			name:  "ruby mode: lone % not followed by > is preserved",
+			input: "<% x = 5 % 2 %>",
+			want:  "   x = 5 % 2   ",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "newline in html mode",
+			input: "hello\nworld",
+			want:  "     \n     ",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(erbToRuby([]byte(tc.input)))
+			if got != tc.want {
+				t.Errorf("erbToRuby(%q)\nwant: %q\n got: %q", tc.input, tc.want, got)
+			}
+		})
+	}
 }
 
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -604,7 +604,7 @@ func TestRubyScanner_Methods(t *testing.T) {
 
 	skipDirs := s.SkipDirs()
 	if !skipDirs["node_modules"] {
-		t.Error("expected node_modules to be in SkipDirs")
+		t.Error("expected node_modules to be in RubySkipDirs")
 	}
 	if !skipDirs["spec"] {
 		t.Error("expected spec to be in RubySkipDirs")
@@ -922,6 +922,21 @@ func TestERBToRuby(t *testing.T) {
 			input: "hello\nworld",
 			want:  "     \n     ",
 		},
+		{
+			name:  "double-quoted string: %> inside is not a closing tag",
+			input: `<%= "%>" %>`,
+			want:  `    "%>"   `,
+		},
+		{
+			name:  "single-quoted string: %> inside is not a closing tag",
+			input: `<%= '%>' %>`,
+			want:  `    '%>'   `,
+		},
+		{
+			name:  "escaped quote inside string does not close string early",
+			input: "<%= \"a\\\"b\" %>",
+			want:  "    \"a\\\"b\"   ",
+		},
 	}
 
 	for _, tc := range tests {
@@ -931,6 +946,19 @@ func TestERBToRuby(t *testing.T) {
 				t.Errorf("erbToRuby(%q)\nwant: %q\n got: %q", tc.input, tc.want, got)
 			}
 		})
+	}
+}
+
+func TestScanRuby_ERBStringLiteralWithPercentGT(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "show.html.erb", `<%= "%>" %>`)
+
+	refs, _, err := ScanRuby(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs (string literal contains %%>, not a call), got %d: %v", len(refs), refs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `ScanRuby` to walk both `.rb` and `.erb` files
- Adds `erbToRuby` state machine that strips ERB markers (`<%= %>`, `<% %>`, `<%# %>`) to Ruby fragments while preserving line numbers
- Introduces `RubySkipDirs` (`spec`, `test`, `vendor`, `migrate`, `node_modules`) separate from the Python `SkipDirs`
- Adds ERB fixture (`app/views/user.html.erb`) to the Rails e2e fixture and asserts it appears in output
- 16 new unit tests + `TestERBToRuby` table test covering all state machine branches; 100% coverage maintained

Closes #35

## Test plan

- [x] `go test -race ./internal/scanner/...` — all 56 tests pass
- [x] `make check-coverage` — 100% across all packages
- [x] `make test-e2e` — Rails e2e now also asserts `app/views/user.html.erb` in output
- [x] Pre-push hook (lint + coverage + benchmarks) all green