### PR TITLE
docs: add issue labeling rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+## GitHub Issues
+
+When creating issues with `gh issue create`, always add relevant labels explicitly with `--label`:
+
+- `orm:django` — issue relates to Django/Python support
+- `orm:rails` — issue relates to Rails/Ruby support
+- `bug` — bug fix (`fix:` prefix)
+- `enhancement` — new feature (`feat:` prefix)
+- `test` — test-only change (`test:` prefix)
+- `ci` — CI/workflow change (`ci:` prefix)


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with a rule to always pass `--label` when creating issues via `gh issue create`
- Avoids the need for fragile keyword-based automation or Web UI-only issue templates

Closes #57