### PR TITLE
docs: add repos/ convention for cloned OSS projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 colref
 e2e/colref-e2e-test
 coverage/
+repos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # CLAUDE.md
 
+## External repositories
+
+When cloning OSS projects for verification or accuracy testing, place them under `repos/` at the project root (e.g. `repos/discourse`, `repos/mastodon`). Do **not** use `/tmp` or `/private/tmp`.
+
+The `repos/` directory is listed in `.gitignore` and is never committed.
+
 ## GitHub Issues
 
 When creating issues with `gh issue create`, always add relevant labels explicitly with `--label`:


### PR DESCRIPTION
## Summary

- Add `repos/` convention to `CLAUDE.md`: clone OSS projects under `repos/` at the project root; `/tmp` and `/private/tmp` must not be used
- Add `repos/` to `.gitignore`

## Test plan

- [ ] `repos/` is listed in `.gitignore`
- [ ] `CLAUDE.md` wording is accurate