### PR TITLE
feat(rails): reconstruct schema from db/migrate/ when schema.rb is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ References found for User.email
 colref check --orm rails --model User --field email
 ```
 
-colref reads `db/schema.rb` from the project root, infers model names from table names (`users` → `User`), and scans `.rb` files for attribute-access references.
+colref reads `db/schema.rb` from the project root, infers model names from table names (`users` → `User`), and scans `.rb` and `.erb` files for attribute-access references.
+
+If `db/schema.rb` is not present (some projects treat it as a generated artifact and do not commit it), colref falls back to `db/migrate/`. It replays migration files in timestamp order — `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table` — to reconstruct the current schema. Model and field validation remain fully intact.
 
 ### Flags
 

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -43,6 +44,10 @@ func runCheckRails(dir, modelName, fieldName string) error {
 	schemaFile := filepath.Join(dir, "db", "schema.rb")
 	src, err := os.ReadFile(schemaFile)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "Warning: %s not found; skipping model and field validation.\n\n", schemaFile)
+			return runScan(dir, modelName, fieldName, scanner.ScanRuby)
+		}
 		return fmt.Errorf("read %s: %w", schemaFile, err)
 	}
 	fields, err := parseSchemaRb(src)
@@ -138,6 +143,10 @@ func runCheckFields(dir, modelName, fieldName string, allFields []parser.Field, 
 			fieldName, modelName, strings.Join(fieldNames, ", "))
 	}
 
+	return runScan(dir, modelName, fieldName, scan)
+}
+
+func runScan(dir, modelName, fieldName string, scan func(string, string) ([]scanner.Reference, int, error)) error {
 	refs, count, err := scan(dir, fieldName)
 	if err != nil {
 		return err

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -25,6 +25,10 @@ var parseModelsWithSet = parser.ParseModelsWithSet
 // It is a var so tests can inject a failing version to cover error paths.
 var parseSchemaRb = parser.ParseSchemaRb
 
+// parseMigrations is the function used to parse db/migrate/ files.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseMigrations = parser.ParseMigrations
+
 // filepathRelFn is the function used to compute relative paths in runCheck.
 // It is a var so tests can inject a failing version to cover error paths.
 var filepathRelFn = filepath.Rel
@@ -45,14 +49,22 @@ func runCheckRails(dir, modelName, fieldName string) error {
 	src, err := os.ReadFile(schemaFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "Warning: %s not found; skipping model and field validation.\n\n", schemaFile)
-			return runScan(dir, modelName, fieldName, scanner.ScanRuby)
+			return runCheckRailsMigrations(dir, modelName, fieldName)
 		}
 		return fmt.Errorf("read %s: %w", schemaFile, err)
 	}
 	fields, err := parseSchemaRb(src)
 	if err != nil {
 		return fmt.Errorf("parse %s: %w", schemaFile, err)
+	}
+	return runCheckFields(dir, modelName, fieldName, fields, scanner.ScanRuby)
+}
+
+func runCheckRailsMigrations(dir, modelName, fieldName string) error {
+	migrateDir := filepath.Join(dir, "db", "migrate")
+	fields, err := parseMigrations(migrateDir)
+	if err != nil {
+		return fmt.Errorf("parse migrations from %s: %w", migrateDir, err)
 	}
 	return runCheckFields(dir, modelName, fieldName, fields, scanner.ScanRuby)
 }

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -413,9 +413,57 @@ func TestRunCheck_Rails_UnknownField(t *testing.T) {
 }
 
 func TestRunCheck_Rails_NoSchemaFile(t *testing.T) {
-	err := runCheck(t.TempDir(), "User", "email", "rails")
+	// No schema.rb present: should warn and scan without field validation.
+	if err := runCheck(t.TempDir(), "User", "email", "rails"); err != nil {
+		t.Fatalf("no-schema path should not error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_NoSchemaFile_RefsFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "app.rb"), []byte("user.email\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCheck(dir, "User", "email", "rails"); err != nil {
+		t.Fatalf("no-schema path with refs should not error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_NoSchemaFile_ScanError(t *testing.T) {
+	dir := t.TempDir()
+	unreadable := filepath.Join(dir, "app.rb")
+	if err := os.WriteFile(unreadable, []byte("user.email\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+	err := runCheck(dir, "User", "email", "rails")
 	if err == nil {
-		t.Fatal("expected error for missing schema.rb")
+		t.Fatal("expected scan error for unreadable .rb file")
+	}
+}
+
+func TestRunCheck_Rails_SchemaReadPermError(t *testing.T) {
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	schemaPath := filepath.Join(dbDir, "schema.rb")
+	if err := os.WriteFile(schemaPath, []byte("# schema"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(schemaPath, 0o644) })
+
+	err := runCheck(dir, "User", "email", "rails")
+	if err == nil {
+		t.Fatal("expected error for unreadable schema.rb")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("expected 'read' in error, got: %v", err)
 	}
 }
 

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -412,37 +412,65 @@ func TestRunCheck_Rails_UnknownField(t *testing.T) {
 	}
 }
 
-func TestRunCheck_Rails_NoSchemaFile(t *testing.T) {
-	// No schema.rb present: should warn and scan without field validation.
-	if err := runCheck(t.TempDir(), "User", "email", "rails"); err != nil {
-		t.Fatalf("no-schema path should not error: %v", err)
-	}
-}
-
-func TestRunCheck_Rails_NoSchemaFile_RefsFound(t *testing.T) {
+func setupRailsMigrationsFixture(t *testing.T) string {
+	t.Helper()
 	dir := t.TempDir()
+	migrateDir := filepath.Join(dir, "db", "migrate")
+	if err := os.MkdirAll(migrateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(migrateDir, "20230101000000_create_users.rb"), []byte(`
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table "users" do |t|
+      t.string "email", null: false
+      t.string "name"
+    end
+  end
+end
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "app.rb"), []byte("user.email\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	return dir
+}
+
+func TestRunCheck_Rails_NoSchemaFile(t *testing.T) {
+	// No schema.rb: fall back to db/migrate/ and reconstruct schema.
+	dir := setupRailsMigrationsFixture(t)
 	if err := runCheck(dir, "User", "email", "rails"); err != nil {
-		t.Fatalf("no-schema path with refs should not error: %v", err)
+		t.Fatalf("migrations fallback should not error: %v", err)
 	}
 }
 
-func TestRunCheck_Rails_NoSchemaFile_ScanError(t *testing.T) {
-	dir := t.TempDir()
-	unreadable := filepath.Join(dir, "app.rb")
-	if err := os.WriteFile(unreadable, []byte("user.email\n"), 0o644); err != nil {
-		t.Fatal(err)
+func TestRunCheck_Rails_NoSchemaFile_NoMigrateDir(t *testing.T) {
+	// Neither schema.rb nor db/migrate/ present.
+	err := runCheck(t.TempDir(), "User", "email", "rails")
+	if err == nil {
+		t.Fatal("expected error when both schema.rb and db/migrate/ are absent")
 	}
-	if err := os.Chmod(unreadable, 0o000); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(err.Error(), "migrate") {
+		t.Errorf("error should mention 'migrate', got: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+}
 
+func TestRunCheck_Rails_NoSchemaFile_ParseMigrationsError(t *testing.T) {
+	orig := parseMigrations
+	parseMigrations = func(dir string) ([]parser.Field, error) {
+		return nil, fmt.Errorf("injected migrations error")
+	}
+	defer func() { parseMigrations = orig }()
+
+	dir := t.TempDir()
+	// No schema.rb triggers the migrations path.
 	err := runCheck(dir, "User", "email", "rails")
 	if err == nil {
-		t.Fatal("expected scan error for unreadable .rb file")
+		t.Fatal("expected error from parseMigrations injection")
+	}
+	if !strings.Contains(err.Error(), "injected migrations error") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -126,12 +126,15 @@ func TestE2E_Rails(t *testing.T) {
 	})
 
 	t.Run("NoSchemaFile", func(t *testing.T) {
-		dir := t.TempDir()
-		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", dir)
-		if err == nil {
-			t.Fatal("expected non-zero exit for missing schema.rb")
+		// schema.rb absent: should warn and scan without validation.
+		fixture := "fixtures/rails-no-schema"
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", fixture)
+		if err != nil {
+			t.Fatalf("no-schema path should not error: %v\noutput:\n%s", err, out)
 		}
 		assertContains(t, out, "schema.rb")
+		assertContains(t, out, "References found for User.email")
+		assertContains(t, out, "app/user.rb")
 	})
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -126,13 +126,12 @@ func TestE2E_Rails(t *testing.T) {
 	})
 
 	t.Run("NoSchemaFile", func(t *testing.T) {
-		// schema.rb absent: should warn and scan without validation.
+		// schema.rb absent: fall back to db/migrate/ for field validation.
 		fixture := "fixtures/rails-no-schema"
 		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", fixture)
 		if err != nil {
 			t.Fatalf("no-schema path should not error: %v\noutput:\n%s", err, out)
 		}
-		assertContains(t, out, "schema.rb")
 		assertContains(t, out, "References found for User.email")
 		assertContains(t, out, "app/user.rb")
 	})

--- a/e2e/fixtures/rails-no-schema/app/user.rb
+++ b/e2e/fixtures/rails-no-schema/app/user.rb
@@ -1,0 +1,2 @@
+user = User.find(params[:id])
+user.email

--- a/e2e/fixtures/rails-no-schema/db/migrate/20230101000000_create_users.rb
+++ b/e2e/fixtures/rails-no-schema/db/migrate/20230101000000_create_users.rb
@@ -1,0 +1,8 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table "users" do |t|
+      t.string "email", null: false
+      t.string "name"
+    end
+  end
+end

--- a/internal/parser/migrations.go
+++ b/internal/parser/migrations.go
@@ -1,0 +1,217 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/ruby"
+)
+
+// ParseMigrations reads all .rb files under migrateDir in filename order
+// (the timestamp prefix ensures chronological order), replays
+// create_table / add_column / remove_column / rename_column / drop_table
+// operations, and returns the resulting column definitions.
+func ParseMigrations(migrateDir string) ([]Field, error) {
+	entries, err := os.ReadDir(migrateDir)
+	if err != nil {
+		return nil, err
+	}
+
+	schema := map[string]map[string]bool{} // table → set of column names
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".rb") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(migrateDir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		if err := applyMigration(schema, src); err != nil {
+			return nil, err
+		}
+	}
+
+	var fields []Field
+	for table, cols := range schema {
+		model := tableToModel(table)
+		for col := range cols {
+			fields = append(fields, Field{Model: model, Name: col})
+		}
+	}
+	return fields, nil
+}
+
+func applyMigration(schema map[string]map[string]bool, src []byte) error {
+	p := sitter.NewParser()
+	p.SetLanguage(ruby.GetLanguage())
+	tree, err := parseCtxFnRuby(p, context.Background(), nil, src)
+	if err != nil {
+		return err
+	}
+	walkMigrationNode(tree.RootNode(), src, schema)
+	return nil
+}
+
+func walkMigrationNode(node *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	if node.Type() == "call" {
+		method := node.ChildByFieldName("method")
+		receiver := node.ChildByFieldName("receiver")
+		if receiver == nil && method != nil {
+			switch method.Content(src) {
+			case "create_table":
+				migCreateTable(node, src, schema)
+				return
+			case "add_column":
+				migAddColumn(node, src, schema)
+				return
+			case "remove_column":
+				migRemoveColumn(node, src, schema)
+				return
+			case "rename_column":
+				migRenameColumn(node, src, schema)
+				return
+			case "drop_table":
+				migDropTable(node, src, schema)
+				return
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkMigrationNode(node.Child(i), src, schema)
+	}
+}
+
+func migCreateTable(callNode *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	table := migArg(args, src, 0)
+	if table == "" {
+		return
+	}
+	if schema[table] == nil {
+		schema[table] = map[string]bool{}
+	}
+	doBlock := findChild(callNode, "do_block")
+	if doBlock == nil {
+		return
+	}
+	body := findChild(doBlock, "body_statement")
+	if body == nil {
+		return
+	}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		stmt := body.Child(i)
+		if stmt.Type() != "call" {
+			continue
+		}
+		colArgs := stmt.ChildByFieldName("arguments")
+		if colArgs == nil {
+			continue
+		}
+		col := migArg(colArgs, src, 0)
+		if col == "" {
+			continue
+		}
+		schema[table][col] = true
+	}
+}
+
+func migAddColumn(callNode *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	table := migArg(args, src, 0)
+	col := migArg(args, src, 1)
+	if table == "" || col == "" {
+		return
+	}
+	if schema[table] == nil {
+		schema[table] = map[string]bool{}
+	}
+	schema[table][col] = true
+}
+
+func migRemoveColumn(callNode *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	table := migArg(args, src, 0)
+	col := migArg(args, src, 1)
+	if table == "" || col == "" {
+		return
+	}
+	if schema[table] != nil {
+		delete(schema[table], col)
+	}
+}
+
+func migRenameColumn(callNode *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	table := migArg(args, src, 0)
+	oldCol := migArg(args, src, 1)
+	newCol := migArg(args, src, 2)
+	if table == "" || oldCol == "" || newCol == "" {
+		return
+	}
+	if schema[table] != nil {
+		delete(schema[table], oldCol)
+		schema[table][newCol] = true
+	}
+}
+
+func migDropTable(callNode *sitter.Node, src []byte, schema map[string]map[string]bool) {
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	table := migArg(args, src, 0)
+	if table == "" {
+		return
+	}
+	delete(schema, table)
+}
+
+// migArg returns the nth string-or-symbol argument (0-indexed).
+// Ruby strings ("col") and symbols (:col) are both accepted.
+func migArg(argList *sitter.Node, src []byte, n int) string {
+	count := 0
+	for i := 0; i < int(argList.ChildCount()); i++ {
+		val := migArgValue(argList.Child(i), src)
+		if val != "" {
+			if count == n {
+				return val
+			}
+			count++
+		}
+	}
+	return ""
+}
+
+func migArgValue(node *sitter.Node, src []byte) string {
+	switch node.Type() {
+	case "string":
+		for j := 0; j < int(node.ChildCount()); j++ {
+			c := node.Child(j)
+			if c.Type() == "string_content" {
+				return c.Content(src)
+			}
+		}
+	case "simple_symbol":
+		content := node.Content(src)
+		if len(content) > 1 && content[0] == ':' {
+			return content[1:]
+		}
+	}
+	return ""
+}

--- a/internal/parser/migrations_test.go
+++ b/internal/parser/migrations_test.go
@@ -476,4 +476,3 @@ drop_table 42
 		t.Errorf("expected no fields, got %v", fields)
 	}
 }
-

--- a/internal/parser/migrations_test.go
+++ b/internal/parser/migrations_test.go
@@ -1,0 +1,479 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func writeMigration(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fieldNames(fields []Field, model string) []string {
+	var names []string
+	for _, f := range fields {
+		if f.Model == model {
+			names = append(names, f.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestParseMigrations_CreateTable(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table "users" do |t|
+      t.string "email", null: false
+      t.string "name"
+    end
+  end
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	want := []string{"email", "name"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseMigrations_SymbolTableName(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+    end
+  end
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_AddColumn(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+create_table :users do |t|
+  t.string :email
+end
+`)
+	writeMigration(t, dir, "20230201000000_add_name_to_users.rb", `
+add_column :users, :name, :string
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	want := []string{"email", "name"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseMigrations_RemoveColumn(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+create_table :users do |t|
+  t.string :email
+  t.string :legacy
+end
+`)
+	writeMigration(t, dir, "20230201000000_remove_legacy.rb", `
+remove_column :users, :legacy
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_RenameColumn(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+create_table :users do |t|
+  t.string :mail
+end
+`)
+	writeMigration(t, dir, "20230201000000_rename_mail.rb", `
+rename_column :users, :mail, :email
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_DropTable(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+create_table :users do |t|
+  t.string :email
+end
+`)
+	writeMigration(t, dir, "20230201000000_drop_users.rb", `
+drop_table :users
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 0 {
+		t.Errorf("expected no fields after drop_table, got %v", got)
+	}
+}
+
+func TestParseMigrations_MultipleModels(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_tables.rb", `
+create_table :users do |t|
+  t.string :email
+end
+create_table :posts do |t|
+  t.string :title
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if names := fieldNames(fields, "User"); len(names) != 1 || names[0] != "email" {
+		t.Errorf("User: got %v", names)
+	}
+	if names := fieldNames(fields, "Post"); len(names) != 1 || names[0] != "title" {
+		t.Errorf("Post: got %v", names)
+	}
+}
+
+func TestParseMigrations_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected empty fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_NonExistentDir(t *testing.T) {
+	_, err := ParseMigrations("/nonexistent/dir/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent directory")
+	}
+}
+
+func TestParseMigrations_UnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20230101000000_create_users.rb")
+	if err := os.WriteFile(path, []byte("create_table :users do |t| end"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, err := ParseMigrations(dir)
+	if err == nil {
+		t.Fatal("expected error for unreadable migration file")
+	}
+}
+
+func TestParseMigrations_ParseError(t *testing.T) {
+	orig := parseCtxFnRuby
+	parseCtxFnRuby = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		return nil, fmt.Errorf("injected parse error")
+	}
+	defer func() { parseCtxFnRuby = orig }()
+
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_create_users.rb", "create_table :users do |t| end")
+
+	_, err := ParseMigrations(dir)
+	if err == nil {
+		t.Fatal("expected error from parse injection")
+	}
+}
+
+func TestParseMigrations_IgnoresNonRbFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# migrations"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeMigration(t, dir, "20230101000000_create_users.rb", `
+create_table :users do |t|
+  t.string :email
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) == 0 {
+		t.Error("expected fields from .rb file")
+	}
+}
+
+func TestParseMigrations_AddColumnMissingArgs(t *testing.T) {
+	dir := t.TempDir()
+	// add_column with only table (no col) — should be silently skipped.
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+add_column :users
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_RemoveColumnMissingArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+remove_column :users
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_RenameColumnMissingArgs(t *testing.T) {
+	dir := t.TempDir()
+	// rename_column with only two args — should be silently skipped.
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+rename_column :users, :old_name
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_RemoveColumnTableNotInSchema(t *testing.T) {
+	dir := t.TempDir()
+	// remove_column on a table that was never created — should be silently skipped.
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+remove_column :ghost, :col
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_RenameColumnTableNotInSchema(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+rename_column :ghost, :old, :new_name
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_CreateTableNoDoBlock(t *testing.T) {
+	dir := t.TempDir()
+	// create_table without a block — table registered but no columns.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table "widgets", force: true
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "Widget")
+	if len(got) != 0 {
+		t.Errorf("expected no columns, got %v", got)
+	}
+}
+
+// TestParseMigrations_NilArgBranches covers defensive nil-arg guards in all
+// operation handlers by passing block-only calls (no argument list).
+func TestParseMigrations_NilArgBranches(t *testing.T) {
+	dir := t.TempDir()
+	// Each call has a block but no argument list → args == nil in all handlers.
+	writeMigration(t, dir, "20230101000000_noop.rb", `
+create_table do |t| end
+add_column do end
+remove_column do end
+rename_column do end
+drop_table do end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+
+func TestParseMigrations_CreateTableInvalidFirstArg(t *testing.T) {
+	dir := t.TempDir()
+	// Integer as first arg → migArg returns "" → table == "" branch.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table 42 do |t|
+  t.string :email
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields for invalid table name, got %v", fields)
+	}
+}
+
+func TestParseMigrations_CreateTableEmptyBlock(t *testing.T) {
+	dir := t.TempDir()
+	// Empty block → body_statement may be absent → body == nil branch.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table :empties do
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "Empty")
+	if len(got) != 0 {
+		t.Errorf("expected no columns, got %v", got)
+	}
+}
+
+func TestParseMigrations_CreateTableNonCallInBlock(t *testing.T) {
+	dir := t.TempDir()
+	// Assignment in block → stmt.Type() != "call" branch.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table :users do |t|
+  x = 1
+  t.string :email
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_CreateTableTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	// t.timestamps has no string/symbol args → colArgs present but col == "".
+	// t.timestamps may also have no argument list at all → colArgs == nil.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table :users do |t|
+  t.timestamps
+  t.string :email
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_CreateTableInvalidColName(t *testing.T) {
+	dir := t.TempDir()
+	// Integer as column name → migArg returns "" → col == "" branch.
+	writeMigration(t, dir, "20230101000000_create.rb", `
+create_table :users do |t|
+  t.string 42
+  t.string :email
+end
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if len(got) != 1 || got[0] != "email" {
+		t.Errorf("got %v, want [email]", got)
+	}
+}
+
+func TestParseMigrations_AddColumnNewTable(t *testing.T) {
+	dir := t.TempDir()
+	// add_column for a table never seen in create_table → schema[table] == nil.
+	writeMigration(t, dir, "20230101000000_add.rb", `
+add_column :brand_new, :col, :string
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "BrandNew")
+	if len(got) != 1 || got[0] != "col" {
+		t.Errorf("got %v, want [col]", got)
+	}
+}
+
+func TestParseMigrations_DropTableInvalidArg(t *testing.T) {
+	dir := t.TempDir()
+	// Integer as table name → migArg returns "" → table == "" branch.
+	writeMigration(t, dir, "20230101000000_drop.rb", `
+drop_table 42
+`)
+	fields, err := ParseMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected no fields, got %v", fields)
+	}
+}
+


### PR DESCRIPTION
## Summary

When `db/schema.rb` is not found, fall back to parsing all `.rb` files under `db/migrate/` in filename order (timestamp prefix = chronological) and replay migration operations to derive the current schema. Field and model validation remain fully intact — only the data source changes.

**Supported operations:** `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table`  
**Both string and symbol arguments** are handled: `"users"` and `:users` are equivalent.

## Implementation

- `internal/parser/migrations.go` — new `ParseMigrations(dir)` function
- `cmd/colref/check.go` — `runCheckRails` falls back to `runCheckRailsMigrations` on `os.ErrNotExist`; `runScan` helper extracted to share the scan+print path
- e2e fixture `fixtures/rails-no-schema/` with `db/migrate/` but no `db/schema.rb`

## Behaviour when schema.rb is absent

```
$ colref check --orm rails --model User --field email /path/to/no-schema-project
Scanning 12 files...

References found for User.email

  app/models/user.rb:42   user.email
```

Field validation still works: `--field bogus` returns an error with available fields.

## Test plan

- [ ] `make check-coverage` passes (100% coverage maintained)
- [ ] Unit tests cover all migration operations and edge cases
- [ ] `TestRunCheck_Rails_NoSchemaFile` now exercises the migrations fallback
- [ ] `TestE2E_Rails/NoSchemaFile` verifies end-to-end with fixture

Closes #61