### PR TITLE
feat(django): support models/ package directories

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/shinagawa-web/colref/internal/orm"
@@ -58,7 +59,7 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		return err
 	}
 	if len(modelsFiles) == 0 {
-		return fmt.Errorf("no models.py or models/ package found under %s", dir)
+		return fmt.Errorf("no models.py or models/*.py found under %s", dir)
 	}
 
 	// Read all sources first so we can build a cross-file model set.
@@ -188,6 +189,7 @@ func findModelsFiles(dir string) ([]string, error) {
 		}
 		return nil
 	})
+	sort.Strings(files)
 	return files, err
 }
 

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -58,7 +58,7 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		return err
 	}
 	if len(modelsFiles) == 0 {
-		return fmt.Errorf("no models.py found under %s", dir)
+		return fmt.Errorf("no models.py or models/ package found under %s", dir)
 	}
 
 	// Read all sources first so we can build a cross-file model set.
@@ -183,7 +183,7 @@ func findModelsFiles(dir string) ([]string, error) {
 			}
 			return nil
 		}
-		if filepath.Base(path) == "models.py" {
+		if filepath.Base(path) == "models.py" || (filepath.Ext(path) == ".py" && filepath.Base(filepath.Dir(path)) == "models") {
 			files = append(files, path)
 		}
 		return nil

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -461,8 +461,8 @@ func TestRunCheck_Django_ModelsPackage_SkipHiddenDir(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error: models/ inside hidden dir should be skipped")
 	}
-	if !strings.Contains(err.Error(), "no models.py") {
-		t.Errorf("unexpected error: %v", err)
+	if !strings.Contains(err.Error(), "models.py") || !strings.Contains(err.Error(), "models/") {
+		t.Errorf("error should mention both models.py and models/, got: %v", err)
 	}
 }
 

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -376,6 +376,96 @@ class User(models.Model):
 	}
 }
 
+func TestRunCheck_Django_ModelsPackage_Basic(t *testing.T) {
+	dir := t.TempDir()
+	modelsDir := filepath.Join(dir, "zerver", "models")
+	if err := os.MkdirAll(modelsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []struct{ name, content string }{
+		{"__init__.py", ""},
+		{"users.py", "from django.db import models\nclass User(models.Model):\n    email = models.EmailField()\n"},
+		{"messages.py", "from django.db import models\nclass Message(models.Model):\n    text = models.TextField()\n"},
+	} {
+		if err := os.WriteFile(filepath.Join(modelsDir, f.name), []byte(f.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "zerver", "views.py"), []byte("def show(u): return u.email\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCheck(dir, "User", "email", "django"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheck_Django_ModelsPackage_CrossFileRef(t *testing.T) {
+	dir := t.TempDir()
+	modelsDir := filepath.Join(dir, "blog", "models")
+	if err := os.MkdirAll(modelsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "users.py"), []byte("from django.db import models\nclass User(models.Model):\n    name = models.CharField(max_length=100)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "posts.py"), []byte("from django.db import models\nfrom blog.models.users import User\nclass Post(User):\n    title = models.CharField(max_length=200)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "blog", "views.py"), []byte("def show(p): return p.title\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCheck(dir, "Post", "title", "django"); err != nil {
+		t.Fatalf("cross-file ref in models package: %v", err)
+	}
+}
+
+func TestRunCheck_Django_ModelsPackage_MixedLayout(t *testing.T) {
+	dir := t.TempDir()
+
+	// app1 uses models.py
+	app1 := filepath.Join(dir, "app1")
+	if err := os.MkdirAll(app1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(app1, "models.py"), []byte("from django.db import models\nclass Product(models.Model):\n    name = models.CharField(max_length=100)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// app2 uses models/ package
+	app2Models := filepath.Join(dir, "app2", "models")
+	if err := os.MkdirAll(app2Models, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(app2Models, "order.py"), []byte("from django.db import models\nclass Order(models.Model):\n    total = models.DecimalField(max_digits=10, decimal_places=2)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runCheck(dir, "Product", "name", "django"); err != nil {
+		t.Fatalf("mixed layout — Product.name: %v", err)
+	}
+	if err := runCheck(dir, "Order", "total", "django"); err != nil {
+		t.Fatalf("mixed layout — Order.total: %v", err)
+	}
+}
+
+func TestRunCheck_Django_ModelsPackage_SkipHiddenDir(t *testing.T) {
+	dir := t.TempDir()
+	hiddenModels := filepath.Join(dir, ".venv", "zerver", "models")
+	if err := os.MkdirAll(hiddenModels, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenModels, "users.py"), []byte("from django.db import models\nclass User(models.Model):\n    email = models.EmailField()\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "User", "email", "django")
+	if err == nil {
+		t.Fatal("expected error: models/ inside hidden dir should be skipped")
+	}
+	if !strings.Contains(err.Error(), "no models.py") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestRunCheck_Rails_RefsFound(t *testing.T) {
 	dir := setupRailsFixture(t)
 	if err := runCheck(dir, "User", "email", "rails"); err != nil {


### PR DESCRIPTION
## Summary

- Extends `findModelsFiles` to discover `*.py` files inside `models/` package directories, in addition to `models.py` files
- Updates the "not found" error message to mention `models/` packages
- Adds 4 new tests: basic package discovery, cross-file reference, mixed layout (some apps use `models.py`, others use `models/`), and skip-hidden-dir

## Test plan

- [ ] `TestRunCheck_Django_ModelsPackage_Basic` — files inside `models/` are discovered
- [ ] `TestRunCheck_Django_ModelsPackage_CrossFileRef` — model defined in one package file, referenced from another
- [ ] `TestRunCheck_Django_ModelsPackage_MixedLayout` — `models.py` and `models/` coexist in the same project
- [ ] `TestRunCheck_Django_ModelsPackage_SkipHiddenDir` — `models/` inside `.venv` or other hidden dirs is ignored
- [ ] All existing tests continue to pass

Closes #65