### PR TITLE
fix(scanner/ruby): emit `;` between adjacent ERB tags so both parse (#64)

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -228,7 +228,13 @@ func erbToRuby(src []byte) []byte {
 				}
 				i++
 			} else if i+1 < len(src) && src[i] == '%' && src[i+1] == '>' {
-				out[i], out[i+1] = ' ', ' '
+				// Terminate the ERB block as a Ruby statement so two
+				// adjacent <%= a %> <%= b %> tags on the same source line
+				// don't collapse into a single ambiguous call when the
+				// surrounding HTML is converted to whitespace. Without the
+				// `;`, tree-sitter parses the second tag as a continuation
+				// of the first, dropping its `call` nodes (issue #64).
+				out[i], out[i+1] = ';', ' '
 				i += 2
 				inRuby = false
 			} else {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/ruby"
 )
 
 func writeFile(t *testing.T, dir, name, content string) {
@@ -614,6 +615,72 @@ func TestRubyScanner_Methods(t *testing.T) {
 	}
 }
 
+// Regression for issue #64: when an ERB file packs two `<%= ... %>` tags on
+// the same source line, the second tag's attribute access used to be
+// dropped entirely — the previous erbToRuby converted both `<%` and `%>` to
+// whitespace, so two adjacent tags became one giant ambiguous Ruby
+// expression that tree-sitter couldn't classify as separate `call` nodes.
+//
+// We assert via the AST walker directly (not ScanRuby) because the scanner
+// dedupes references by line number — that dedupe is correct for
+// user-facing output but masks the underlying parse fix here.
+func TestScanRuby_TwoERBTagsSameLine_BothCallsParsed(t *testing.T) {
+	dir := t.TempDir()
+	src := []byte(`<%= t 'mailer.title', name: @resource.account.username %> <%= other.account.username %>
+`)
+	writeFile(t, dir, "welcome.text.erb", string(src))
+
+	converted := erbToRuby(src)
+	parser := sitter.NewParser()
+	parser.SetLanguage(ruby.GetLanguage())
+	tree, err := parser.ParseCtx(context.Background(), nil, converted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refs []Reference
+	walkNodeRuby(tree.RootNode(), converted, [][]byte{converted}, "username", "welcome.text.erb", &refs)
+	if len(refs) != 2 {
+		t.Fatalf("want 2 calls (one per ERB tag) reachable from the parse tree, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "@resource.account.username" {
+		t.Errorf("first call text = %q, want %q", refs[0].Text, "@resource.account.username")
+	}
+	if refs[1].Text != "other.account.username" {
+		t.Errorf("second call text = %q, want %q", refs[1].Text, "other.account.username")
+	}
+}
+
+// Regression for issue #64: keyword-arg method call without parentheses,
+// followed (across `do…end`) by an attribute access on the right-hand side
+// of `||`. Both attribute accesses must be reported.
+func TestScanRuby_KwargNoParensAndOrRHS(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "welcome.text.erb", `<%= t 'mailer.title', name: @resource.account.username %>
+
+<%- @suggestions.each do |s| %>
+* <%= s.account.display_name.presence || s.account.username %>
+<%- end %>
+`)
+
+	refs, _, err := ScanRuby(dir, "username")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs (line 1 kwarg, line 4 ||-RHS), got %d: %v", len(refs), refs)
+	}
+	gotLines := map[int]bool{}
+	for _, r := range refs {
+		gotLines[r.Line] = true
+	}
+	if !gotLines[1] {
+		t.Errorf("missing ref on line 1 (kwarg-no-parens): %v", refs)
+	}
+	if !gotLines[4] {
+		t.Errorf("missing ref on line 4 (||-RHS inside do-end block): %v", refs)
+	}
+}
+
 func TestScanRuby_SkipSpecDir(t *testing.T) {
 	dir := t.TempDir()
 	specDir := filepath.Join(dir, "spec")
@@ -870,22 +937,22 @@ func TestERBToRuby(t *testing.T) {
 		{
 			name:  "output tag content preserved",
 			input: "<%= user.email %>",
-			want:  "    user.email   ",
+			want:  "    user.email ; ",
 		},
 		{
 			name:  "non-output tag content preserved",
 			input: "<% user.email %>",
-			want:  "   user.email   ",
+			want:  "   user.email ; ",
 		},
 		{
 			name:  "dash modifier opening",
 			input: "<%= @user.email -%>",
-			want:  "    @user.email -  ",
+			want:  "    @user.email -; ",
 		},
 		{
 			name:  "dash modifier in opening tag (<%- )",
 			input: "<%- user.email %>",
-			want:  "    user.email   ",
+			want:  "    user.email ; ",
 		},
 		{
 			name:  "comment tag: content replaced with spaces",
@@ -900,7 +967,7 @@ func TestERBToRuby(t *testing.T) {
 		{
 			name:  "comment then expression",
 			input: "<%# x %><%= user.email %>",
-			want:  "            user.email   ",
+			want:  "            user.email ; ",
 		},
 		{
 			name:  "lone < not followed by % is replaced with space",
@@ -910,7 +977,7 @@ func TestERBToRuby(t *testing.T) {
 		{
 			name:  "ruby mode: lone % not followed by > is preserved",
 			input: "<% x = 5 % 2 %>",
-			want:  "   x = 5 % 2   ",
+			want:  "   x = 5 % 2 ; ",
 		},
 		{
 			name:  "empty input",
@@ -925,17 +992,22 @@ func TestERBToRuby(t *testing.T) {
 		{
 			name:  "double-quoted string: %> inside is not a closing tag",
 			input: `<%= "%>" %>`,
-			want:  `    "%>"   `,
+			want:  `    "%>" ; `,
 		},
 		{
 			name:  "single-quoted string: %> inside is not a closing tag",
 			input: `<%= '%>' %>`,
-			want:  `    '%>'   `,
+			want:  `    '%>' ; `,
 		},
 		{
 			name:  "escaped quote inside string does not close string early",
 			input: "<%= \"a\\\"b\" %>",
-			want:  "    \"a\\\"b\"   ",
+			want:  "    \"a\\\"b\" ; ",
+		},
+		{
+			name:  "two adjacent ERB tags on same source line emit `; ` so each becomes a separate Ruby statement (issue #64)",
+			input: "<%= a %> <%= b %>",
+			want:  "    a ;      b ; ",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes #64.

When an ERB file packs two \`<%= ... %>\` tags onto the same source line, the Ruby scanner was dropping every attribute access in the *second* tag. Mastodon's \`app/views/user_mailer/welcome.text.erb\` is the trigger from the report — line 1 has \`<%= t 'mailer.welcome.title', name: @resource.account.username %>\` followed by a second \`<%= ... %>\` on the same line, and \`colref check --orm rails --model Account --field username\` reported zero hits for a file \`grep\` shows two hits in.

## Root cause

\`erbToRuby\` converts ERB markers to spaces to preserve byte offsets — but with both \`<%\`/\`<%=\` *and* \`%>\` becoming whitespace, two adjacent ERB blocks collapse into one ambiguous Ruby expression. For

\`\`\`
<%= a %> <%= b %>
\`\`\`

the converter produced

\`\`\`
        a       b
\`\`\`

and tree-sitter's Ruby grammar (which recovers aggressively across whitespace) wrapped the whole thing as one \`call\` whose \`method\` field was neither \`a\` nor \`b\` — so \`walkNodeRuby\` saw no matching \`call\` node for either side.

## Fix

Terminate each ERB block as its own Ruby statement: convert \`%>\` to \`; \` instead of \`  \`. Still two bytes, so byte offsets remain valid; tree-sitter now parses each \`<%= ... %>\` as a separate statement and produces one \`call\` node per tag.

## Tests

- \`TestScanRuby_TwoERBTagsSameLine_BothCallsParsed\` — walks the parse tree directly (bypassing \`dedupeByLine\`, which is correct user-facing behaviour but masks the underlying parse fix) to assert both calls are reachable.
- \`TestScanRuby_KwargNoParensAndOrRHS\` — covers both patterns the issue calls out: kwarg without parens (\`t 'k', name: x.y\`) and \`||\` right-hand side inside a \`do…end\` block, on different lines so dedupe doesn't mask the second.
- \`TestERBToRuby\` — every existing case updated to expect the \`; \` terminator. One new case (\`<%= a %> <%= b %>\` → \`    a ;      b ; \`) pins the adjacent-tags shape so a future change can't silently regress it.

## Test plan

- [x] \`make test\` (\`go test ./internal/...\`) — all unit tests pass
- [x] \`make test-e2e\` — all e2e tests pass
- [x] \`go vet ./...\` — clean
- [x] \`gofmt -d\` — clean

Mastodon-style scenario (synthetic, but mirrors the bug from the issue):

\`\`\`erb
<%= t 'mailer.title', name: @resource.account.username %>

<%- @suggestions.each do |s| %>
* <%= s.account.display_name.presence || s.account.username %>
<%- end %>
\`\`\`

Before: \`colref … --field username …\` returns 0 refs for the file.  
After: returns 2 refs (line 1 kwarg, line 4 \`||\`-RHS).