### PR TITLE
fix(rails): require receiver on Ruby call nodes to avoid false positives

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -175,10 +175,13 @@ func lineAt(lines [][]byte, row int) string {
 
 // walkNodeRuby matches Ruby method calls (call nodes) where the method name
 // equals fieldName, e.g. user.email → matches "email".
+// A receiver is required to avoid false positives on standalone method calls
+// like raw(string) or send(msg) that share a name with the target field.
 func walkNodeRuby(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
 	if node.Type() == "call" {
 		method := node.ChildByFieldName("method")
-		if method != nil && method.Content(src) == fieldName {
+		receiver := node.ChildByFieldName("receiver")
+		if method != nil && receiver != nil && method.Content(src) == fieldName {
 			methodRow := int(method.StartPoint().Row)
 			text := node.Content(src)
 			if int(node.StartPoint().Row) != methodRow {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -588,6 +588,27 @@ func TestScanRuby_NoMatch(t *testing.T) {
 	}
 }
 
+func TestScanRuby_StandaloneCallNotMatched(t *testing.T) {
+	dir := t.TempDir()
+	// raw(string) is a Rails helper called without a receiver.
+	// It must not be reported as a reference to the "raw" field.
+	writeFile(t, dir, "app.rb", `
+raw(some_string)
+user.raw
+`)
+
+	refs, _, err := ScanRuby(dir, "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (user.raw only), got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "user.raw" {
+		t.Errorf("want user.raw, got %q", refs[0].Text)
+	}
+}
+
 func TestRubyScanner_Methods(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "app.rb", `user.email`)


### PR DESCRIPTION
## Problem

`walkNodeRuby` matched any `call` node where the method name equalled `--field`, without checking whether the call had a receiver:

```go
if method != nil && method.Content(src) == fieldName {
```

This caused false positives when the field name coincided with a standalone Rails/Ruby helper. Discovered during Discourse accuracy check (#38): `--field raw` produced 67 false positives from ActionView's `raw(string)` helper (called without a receiver).

## Fix

Added `receiver != nil` guard:

```go
receiver := node.ChildByFieldName("receiver")
if method != nil && receiver != nil && method.Content(src) == fieldName {
```

## Test

`TestScanRuby_StandaloneCallNotMatched` — verifies that `raw(some_string)` is not reported while `user.raw` is.

Closes #67