### PR TITLE
test(e2e): add coverage for models/ package, advanced migrations, and model conflict

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -137,6 +137,60 @@ func TestE2E_Rails(t *testing.T) {
 	})
 }
 
+func TestE2E_Django_ModelsPackage(t *testing.T) {
+	fixture := "fixtures/django-models-pkg"
+
+	t.Run("RefsFound", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for User.email")
+		assertContains(t, out, "accounts/views.py")
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "name", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "No references found for User.name")
+	})
+}
+
+func TestE2E_Django_Conflict(t *testing.T) {
+	out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "fixtures/django-conflict")
+	if err == nil {
+		t.Fatal("expected non-zero exit for duplicate model definition")
+	}
+	assertContains(t, out, "multiple files")
+	assertContains(t, out, "app1/models.py")
+	assertContains(t, out, "app2/models.py")
+}
+
+func TestE2E_Rails_Migrations(t *testing.T) {
+	fixture := "fixtures/rails-migrations"
+
+	t.Run("AddColumnRefsFound", func(t *testing.T) {
+		// age is added via add_column, not present in create_table.
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "age", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for User.age")
+		assertContains(t, out, "app/user.rb")
+	})
+
+	t.Run("RemovedColumnNotFound", func(t *testing.T) {
+		// legacy_token was created in create_table but removed by remove_column.
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "legacy_token", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for removed column")
+		}
+		assertContains(t, out, `"legacy_token" not found`)
+	})
+}
+
 func TestE2E_UnknownOrm(t *testing.T) {
 	out, err := run(t, "check", "--orm", "typeorm", "--model", "User", "--field", "email", "fixtures/django")
 	if err == nil {

--- a/e2e/fixtures/django-conflict/app1/models.py
+++ b/e2e/fixtures/django-conflict/app1/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class User(models.Model):
+    email = models.EmailField()

--- a/e2e/fixtures/django-conflict/app2/models.py
+++ b/e2e/fixtures/django-conflict/app2/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class User(models.Model):
+    email = models.EmailField()

--- a/e2e/fixtures/django-models-pkg/accounts/models/user.py
+++ b/e2e/fixtures/django-models-pkg/accounts/models/user.py
@@ -1,0 +1,6 @@
+from django.db import models
+
+
+class User(models.Model):
+    email = models.EmailField()
+    name = models.CharField(max_length=100)

--- a/e2e/fixtures/django-models-pkg/accounts/views.py
+++ b/e2e/fixtures/django-models-pkg/accounts/views.py
@@ -1,0 +1,2 @@
+def send_notification(user):
+    return user.email

--- a/e2e/fixtures/rails-migrations/app/user.rb
+++ b/e2e/fixtures/rails-migrations/app/user.rb
@@ -1,0 +1,3 @@
+user = User.find(params[:id])
+user.email
+user.age

--- a/e2e/fixtures/rails-migrations/db/migrate/20230101000000_create_users.rb
+++ b/e2e/fixtures/rails-migrations/db/migrate/20230101000000_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table "users" do |t|
+      t.string "email", null: false
+      t.string "name"
+      t.string "legacy_token"
+    end
+  end
+end

--- a/e2e/fixtures/rails-migrations/db/migrate/20230102000000_add_age_to_users.rb
+++ b/e2e/fixtures/rails-migrations/db/migrate/20230102000000_add_age_to_users.rb
@@ -1,0 +1,5 @@
+class AddAgeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column "users", "age", :integer
+  end
+end

--- a/e2e/fixtures/rails-migrations/db/migrate/20230103000000_remove_legacy_token_from_users.rb
+++ b/e2e/fixtures/rails-migrations/db/migrate/20230103000000_remove_legacy_token_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveLegacyTokenFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column "users", "legacy_token"
+  end
+end


### PR DESCRIPTION
## Summary

Three code paths had unit-test coverage but no end-to-end test. This PR fills all three gaps identified in #76.

- **Django `models/` package** (`fixtures/django-models-pkg`): fixture with `models/__init__.py` + `models/user.py` layout, verifying references are found via `accounts/views.py` and "no refs" is reported correctly
- **Django model conflict** (`fixtures/django-conflict`): two apps each defining a `User` model, asserting non-zero exit and that the error shows relative paths (`app1/models.py`, `app2/models.py`)
- **Rails advanced migrations** (`fixtures/rails-migrations`): three migration files — `create_table` → `add_column :age` → `remove_column :legacy_token` — verifying that a field added via `add_column` is recognized and a field removed via `remove_column` is rejected as unknown

## New tests

| Test | Subtests |
|------|----------|
| `TestE2E_Django_ModelsPackage` | `RefsFound`, `NoRefs` |
| `TestE2E_Django_Conflict` | — |
| `TestE2E_Rails_Migrations` | `AddColumnRefsFound`, `RemovedColumnNotFound` |

## Test plan

- [x] All 7 new subtests pass
- [x] All existing e2e tests still pass

Closes #76