### PR TITLE
fix(rails): handle -ses/-xes/-zes/-ches/-shes plurals in singularize

### DIFF
--- a/internal/parser/schema_rb.go
+++ b/internal/parser/schema_rb.go
@@ -144,6 +144,10 @@ func singularize(word string) string {
 		return word[:len(word)-3] + "y"
 	case strings.HasSuffix(word, "sses"):
 		return word[:len(word)-2]
+	case strings.HasSuffix(word, "xes"), strings.HasSuffix(word, "zes"),
+		strings.HasSuffix(word, "ches"), strings.HasSuffix(word, "shes"),
+		strings.HasSuffix(word, "ses"):
+		return word[:len(word)-2]
 	case strings.HasSuffix(word, "s") && len(word) > 1:
 		return word[:len(word)-1]
 	default:

--- a/internal/parser/schema_rb_test.go
+++ b/internal/parser/schema_rb_test.go
@@ -227,6 +227,12 @@ func TestTableToModel(t *testing.T) {
 		{"order_items", "OrderItem"},
 		{"admin_users", "AdminUser"},
 		{"data", "Data"},
+		{"statuses", "Status"},
+		{"scheduled_statuses", "ScheduledStatus"},
+		{"custom_filter_statuses", "CustomFilterStatus"},
+		{"boxes", "Box"},
+		{"churches", "Church"},
+		{"dishes", "Dish"},
 	}
 	for _, c := range cases {
 		got := tableToModel(c.table)
@@ -249,6 +255,12 @@ func TestSingularize(t *testing.T) {
 		{"data", "data"},
 		{"s", "s"},
 		{"ies", "ie"},
+		// -ses/-xes/-zes/-ches/-shes → strip -es
+		{"statuses", "status"},
+		{"boxes", "box"},
+		{"buzzes", "buzz"},
+		{"churches", "church"},
+		{"dishes", "dish"},
 	}
 	for _, c := range cases {
 		got := singularize(c.in)


### PR DESCRIPTION
## Summary

- Naive `TrimSuffix("s")` produced wrong model names for tables whose plural ends in `-es` (e.g. `statuses` → `Statuse`, `boxes` → `Boxe`)
- Add explicit cases for `-xes`, `-zes`, `-ches`, `-shes`, `-ses` in `singularize()`, ordered after the existing `-sses` rule so `addresses` → `Address` still works correctly
- Add test cases to `TestSingularize` and `TestTableToModel` covering the new patterns

## Test plan

- [ ] `go test ./internal/parser/... -run TestSingularize` passes
- [ ] `go test ./internal/parser/... -run TestTableToModel` passes
- [ ] `make test-e2e` passes

Closes #62