### PR TITLE
feat(django): scan abstract_models.py (django-oscar pattern)

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -76,7 +76,7 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		return err
 	}
 	if len(modelsFiles) == 0 {
-		return fmt.Errorf("no models.py or models/*.py found under %s", dir)
+		return fmt.Errorf("no models.py, abstract_models.py, or models/*.py found under %s", dir)
 	}
 
 	// Read all sources first so we can build a cross-file model set.
@@ -205,7 +205,8 @@ func findModelsFiles(dir string) ([]string, error) {
 			}
 			return nil
 		}
-		if filepath.Base(path) == "models.py" || (filepath.Ext(path) == ".py" && filepath.Base(filepath.Dir(path)) == "models") {
+		base := filepath.Base(path)
+		if base == "models.py" || base == "abstract_models.py" || (filepath.Ext(path) == ".py" && filepath.Base(filepath.Dir(path)) == "models") {
 			files = append(files, path)
 		}
 		return nil

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -448,6 +448,51 @@ func TestRunCheck_Django_ModelsPackage_MixedLayout(t *testing.T) {
 	}
 }
 
+func TestRunCheck_Django_AbstractModels_Basic(t *testing.T) {
+	dir := t.TempDir()
+	app := filepath.Join(dir, "catalogue")
+	if err := os.MkdirAll(app, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abstractContent := "from django.db import models\nclass AbstractProductClass(models.Model):\n    name = models.CharField(max_length=255)\n    class Meta:\n        abstract = True\n"
+	modelsContent := "from catalogue.abstract_models import AbstractProductClass\nclass ProductClass(AbstractProductClass):\n    pass\n"
+	viewContent := "def show(p): return p.name\n"
+	for _, f := range []struct{ path, content string }{
+		{filepath.Join(app, "abstract_models.py"), abstractContent},
+		{filepath.Join(app, "models.py"), modelsContent},
+		{filepath.Join(dir, "catalogue", "views.py"), viewContent},
+	} {
+		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Fields are declared on AbstractProductClass; users query the abstract class directly.
+	if err := runCheck(dir, "AbstractProductClass", "name", "django"); err != nil {
+		t.Fatalf("abstract_models.py pattern: %v", err)
+	}
+}
+
+func TestRunCheck_Django_AbstractModels_OnlyAbstractFile(t *testing.T) {
+	dir := t.TempDir()
+	app := filepath.Join(dir, "catalogue")
+	if err := os.MkdirAll(app, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abstractContent := "from django.db import models\nclass AbstractProduct(models.Model):\n    slug = models.SlugField()\n    class Meta:\n        abstract = True\n"
+	viewContent := "def show(p): return p.slug\n"
+	for _, f := range []struct{ path, content string }{
+		{filepath.Join(app, "abstract_models.py"), abstractContent},
+		{filepath.Join(dir, "catalogue", "views.py"), viewContent},
+	} {
+		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := runCheck(dir, "AbstractProduct", "slug", "django"); err != nil {
+		t.Fatalf("abstract_models.py only: %v", err)
+	}
+}
+
 func TestRunCheck_Django_ModelsPackage_SkipHiddenDir(t *testing.T) {
 	dir := t.TempDir()
 	hiddenModels := filepath.Join(dir, ".venv", "zerver", "models")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -158,6 +158,27 @@ func TestE2E_Django_ModelsPackage(t *testing.T) {
 	})
 }
 
+func TestE2E_Django_AbstractModels(t *testing.T) {
+	fixture := "fixtures/django-abstract-models"
+
+	t.Run("RefsFound", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "AbstractProductClass", "--field", "name", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for AbstractProductClass.name")
+		assertContains(t, out, "catalogue/views.py")
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "AbstractProductClass", "--field", "slug", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "No references found for AbstractProductClass.slug")
+	})
+}
+
 func TestE2E_Django_Conflict(t *testing.T) {
 	out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "fixtures/django-conflict")
 	if err == nil {

--- a/e2e/fixtures/django-abstract-models/catalogue/abstract_models.py
+++ b/e2e/fixtures/django-abstract-models/catalogue/abstract_models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class AbstractProductClass(models.Model):
+    name = models.CharField(max_length=255)
+    slug = models.SlugField(unique=True)
+
+    class Meta:
+        abstract = True

--- a/e2e/fixtures/django-abstract-models/catalogue/models.py
+++ b/e2e/fixtures/django-abstract-models/catalogue/models.py
@@ -1,0 +1,5 @@
+from catalogue.abstract_models import AbstractProductClass
+
+
+class ProductClass(AbstractProductClass):
+    pass

--- a/e2e/fixtures/django-abstract-models/catalogue/views.py
+++ b/e2e/fixtures/django-abstract-models/catalogue/views.py
@@ -1,0 +1,2 @@
+def show(p):
+    return p.name


### PR DESCRIPTION
## Summary

- colref only matched `models.py` and `models/*.py`, so projects using the django-oscar pattern (`abstract_models.py` for field declarations) returned "model not found" for every model
- Add `abstract_models.py` to the filename check in `findModelsFiles`
- Update the no-files-found error message to mention `abstract_models.py`
- Add unit tests and e2e fixture/tests for the new pattern

## Test plan

- [ ] `go test ./cmd/colref/... -run TestRunCheck_Django_AbstractModels` passes
- [ ] `make test-e2e` passes (new `TestE2E_Django_AbstractModels` subtests)

Closes #70