### PR TITLE
feat(scanner): detect Django string-based ORM references (#71)

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -138,7 +138,7 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		allFields = append(allFields, pf.fields...)
 	}
 
-	return runCheckFields(dir, modelName, fieldName, allFields, scanner.Scan)
+	return runCheckFields(dir, modelName, fieldName, allFields, scanner.ScanDjango)
 }
 
 func runCheckFields(dir, modelName, fieldName string, allFields []parser.Field, scan func(string, string) ([]scanner.Reference, int, error)) error {
@@ -169,7 +169,6 @@ func runScan(dir, modelName, fieldName string, scan func(string, string) ([]scan
 
 	if len(refs) == 0 {
 		fmt.Printf("No references found for %s.%s\n\n", modelName, fieldName)
-		fmt.Printf("  String-based ORM calls (e.g. .values(), .defer()) are not detected.\n")
 		fmt.Printf("  Verify manually before deleting.\n")
 		return nil
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -23,7 +24,7 @@ type PythonScanner struct{}
 
 // Scan implements orm.ReferenceScanner.
 func (PythonScanner) Scan(dir, fieldName string) ([]orm.Reference, int, error) {
-	return Scan(dir, fieldName)
+	return ScanDjango(dir, fieldName)
 }
 
 // SkipDirs implements orm.ReferenceScanner, returning a defensive copy.
@@ -84,6 +85,48 @@ var filepathRelFn = filepath.Rel
 // equals fieldName, along with the total number of .py files examined.
 func Scan(dir, fieldName string) ([]Reference, int, error) {
 	return scanFiles(dir, fieldName, map[string]func([]byte) []byte{".py": nil}, python.GetLanguage(), walkNode, SkipDirs)
+}
+
+// positionalStringMethods are Django ORM methods whose string positional arguments
+// name a model field.
+var positionalStringMethods = map[string]bool{
+	"values": true, "values_list": true, "defer": true, "only": true,
+	"order_by": true, "select_related": true, "prefetch_related": true,
+}
+
+// keywordArgMethods are Django ORM methods (and Q) whose keyword argument names
+// refer to model fields (possibly with lookup suffixes like __icontains).
+var keywordArgMethods = map[string]bool{
+	"filter": true, "exclude": true, "annotate": true, "Q": true,
+}
+
+// ScanStringRefs walks dir and returns every string-based Django ORM reference
+// to fieldName: positional string args in values/defer/only/etc., keyword arg
+// names in filter/exclude/Q, and the first arg of F(). Each reference's Text
+// is prefixed with "[string] ".
+func ScanStringRefs(dir, fieldName string) ([]Reference, int, error) {
+	return scanFiles(dir, fieldName, map[string]func([]byte) []byte{".py": nil}, python.GetLanguage(), walkNodeStringRefs, SkipDirs)
+}
+
+// ScanDjango combines attribute-access and string-based ORM scanning for
+// Django projects. Results are merged and sorted by (File, Line).
+func ScanDjango(dir, fieldName string) ([]Reference, int, error) {
+	attrRefs, count, err := Scan(dir, fieldName)
+	if err != nil {
+		return nil, 0, err
+	}
+	strRefs, _, err := ScanStringRefs(dir, fieldName)
+	if err != nil {
+		return nil, 0, err
+	}
+	refs := append(attrRefs, strRefs...)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].File != refs[j].File {
+			return refs[i].File < refs[j].File
+		}
+		return refs[i].Line < refs[j].Line
+	})
+	return refs, count, nil
 }
 
 // ScanRuby walks dir and returns every method-call node whose method name
@@ -272,6 +315,92 @@ func erbToRuby(src []byte) []byte {
 		}
 	}
 	return out
+}
+
+// walkNodeStringRefs finds string-based Django ORM references to fieldName.
+func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
+	if node.Type() == "call" {
+		fn := node.ChildByFieldName("function")
+		if fn != nil {
+			methodName := callMethodName(fn, src)
+			args := node.ChildByFieldName("arguments")
+			if args != nil {
+				switch {
+				case methodName == "F":
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() == "string" {
+							if stringContent(child, src) == fieldName {
+								addStringRef(child, lines, file, refs)
+							}
+							break
+						}
+					}
+				case positionalStringMethods[methodName]:
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() == "string" && stringContent(child, src) == fieldName {
+							addStringRef(child, lines, file, refs)
+						}
+					}
+				case keywordArgMethods[methodName]:
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() == "keyword_argument" {
+							nameNode := child.ChildByFieldName("name")
+							if nameNode != nil {
+								kwName := nameNode.Content(src)
+								if idx := strings.Index(kwName, "__"); idx >= 0 {
+									kwName = kwName[:idx]
+								}
+								if kwName == fieldName {
+									addStringRef(nameNode, lines, file, refs)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkNodeStringRefs(node.Child(i), src, lines, fieldName, file, refs)
+	}
+}
+
+// callMethodName extracts the method name from a function node (attribute or identifier).
+func callMethodName(fn *sitter.Node, src []byte) string {
+	switch fn.Type() {
+	case "attribute":
+		attr := fn.ChildByFieldName("attribute")
+		if attr != nil {
+			return attr.Content(src)
+		}
+	case "identifier":
+		return fn.Content(src)
+	}
+	return ""
+}
+
+// stringContent returns the string_content of a string node, or "".
+func stringContent(node *sitter.Node, src []byte) string {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		if c.Type() == "string_content" {
+			return c.Content(src)
+		}
+	}
+	return ""
+}
+
+// addStringRef appends a [string]-labeled Reference using the node's source row.
+func addStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
+	row := int(node.StartPoint().Row)
+	*refs = append(*refs, Reference{
+		File: file,
+		Line: row + 1,
+		Text: "[string] " + strings.TrimSpace(lineAt(lines, row)),
+	})
 }
 
 func walkNode(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -502,7 +503,7 @@ func TestPythonScanner_Methods(t *testing.T) {
 
 func TestScan_FExpression_NotDetected(t *testing.T) {
 	dir := t.TempDir()
-	// v0.1 limitation: F('email') passes the column as a string.
+	// Attribute-only scan: F('email') passes the column as a string, not detected.
 	writeFile(t, dir, "views.py", `from django.db.models import F; User.objects.update(email=F("email"))`)
 
 	refs, _, err := Scan(dir, "email")
@@ -510,7 +511,289 @@ func TestScan_FExpression_NotDetected(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(refs) != 0 {
-		t.Errorf("F() expression should not be detected in v0.1, got %d: %v", len(refs), refs)
+		t.Errorf("F() expression should not be detected by attribute scan, got %d: %v", len(refs), refs)
+	}
+}
+
+// --- ScanStringRefs tests ---
+
+func TestScanStringRefs_FilterKwarg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.filter(email="x@example.com")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for filter kwarg, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_FilterKwargLookup(t *testing.T) {
+	dir := t.TempDir()
+	// email__icontains → strip lookup suffix → "email"
+	writeFile(t, dir, "views.py", `qs = User.objects.filter(email__icontains="x")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for filter kwarg with lookup, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_ExcludeKwarg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.exclude(email="x")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for exclude kwarg, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_ValuesListString(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.values_list("email", flat=True)`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for values_list string, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_ValuesString(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.values("email", "name")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for values() string arg, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_DeferOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+qs1 = User.objects.defer("email")
+qs2 = User.objects.only("email")
+`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs for defer+only, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_OrderBy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.order_by("email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for order_by, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_QObject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `from django.db.models import Q; qs = User.objects.filter(Q(email="x"))`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for Q() kwarg, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_FExpression(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `from django.db.models import F; qs = User.objects.filter(score=F("email"))`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for F() expression, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_GetAttrNotDetected(t *testing.T) {
+	dir := t.TempDir()
+	// getattr() is not a Django ORM method — should not be detected.
+	writeFile(t, dir, "views.py", `v = getattr(user, "email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("getattr() should not be detected by ScanStringRefs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_NoMatchOtherField(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.filter(name="Alice")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("filter on different field should not match, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_StringLabel(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.values("email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d", len(refs))
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
+}
+
+// --- ScanDjango tests ---
+
+func TestScanDjango_MergesAttrAndString(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+x = user.email
+qs = User.objects.filter(email="x@example.com")
+`)
+
+	refs, count, err := ScanDjango(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("want 1 file scanned, got %d", count)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs (attr + string), got %d: %v", len(refs), refs)
+	}
+	// Results should be sorted by line; attr ref is line 2, string ref is line 3.
+	if refs[0].Line != 2 || refs[1].Line != 3 {
+		t.Errorf("want lines [2,3], got [%d,%d]", refs[0].Line, refs[1].Line)
+	}
+	if strings.HasPrefix(refs[0].Text, "[string]") {
+		t.Errorf("first ref (attr) should not have [string] prefix, got %q", refs[0].Text)
+	}
+	if !strings.HasPrefix(refs[1].Text, "[string] ") {
+		t.Errorf("second ref (string) should have [string] prefix, got %q", refs[1].Text)
+	}
+}
+
+func TestScanDjango_SortedByFileLine(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.py", `qs = User.objects.filter(email="x")`)
+	writeFile(t, dir, "b.py", `x = user.email`)
+
+	refs, _, err := ScanDjango(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs, got %d: %v", len(refs), refs)
+	}
+	if refs[0].File > refs[1].File {
+		t.Errorf("want sorted by file: got %q before %q", refs[0].File, refs[1].File)
+	}
+}
+
+func TestScanDjango_ScanError(t *testing.T) {
+	orig := parseCtxFn
+	t.Cleanup(func() { parseCtxFn = orig })
+	parseCtxFn = func(_ *sitter.Parser, _ context.Context, _ *sitter.Tree, _ []byte) (*sitter.Tree, error) {
+		return nil, fmt.Errorf("injected scan error")
+	}
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.email`)
+	_, _, err := ScanDjango(dir, "email")
+	if err == nil {
+		t.Fatal("expected error from Scan, got nil")
+	}
+}
+
+func TestScanDjango_StringRefsError(t *testing.T) {
+	call := 0
+	orig := parseCtxFn
+	t.Cleanup(func() { parseCtxFn = orig })
+	parseCtxFn = func(p *sitter.Parser, ctx context.Context, oldTree *sitter.Tree, src []byte) (*sitter.Tree, error) {
+		call++
+		if call <= 1 {
+			return orig(p, ctx, oldTree, src)
+		}
+		return nil, fmt.Errorf("injected string refs error")
+	}
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `x = user.email`)
+	_, _, err := ScanDjango(dir, "email")
+	if err == nil {
+		t.Fatal("expected error from ScanStringRefs, got nil")
+	}
+}
+
+func TestScanStringRefs_SubscriptCallNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	// Subscript call: function node type is "subscript", not attribute/identifier.
+	// callMethodName returns "" → no known ORM method → no refs emitted.
+	writeFile(t, dir, "views.py", `funcs[0]("email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("subscript call should not produce refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_EmptyStringArgNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	// Empty string arg: stringContent returns "" which doesn't match fieldName.
+	writeFile(t, dir, "views.py", `qs = User.objects.values("")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("empty string arg should not match, got %d: %v", len(refs), refs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `ScanStringRefs()` — walks Python files and detects field names passed as strings to Django ORM methods
- Add `ScanDjango()` — combines attribute-access (`Scan`) and string-based scanning, merging and sorting results by file/line
- String-based references are tagged with a `[string]` label inline in the output
- Update `runCheckDjango` to use `ScanDjango` instead of `Scan`

### Detected patterns

| Pattern | Example |
|---|---|
| `.filter()` / `.exclude()` keyword args | `qs.filter(email__icontains='x')` |
| `.values()` / `.values_list()` positional args | `qs.values('email', 'name')` |
| `.defer()` / `.only()` positional args | `qs.defer('email')` |
| `.order_by()` positional args | `qs.order_by('email')` |
| `.select_related()` / `.prefetch_related()` args | `qs.select_related('email')` |
| `Q(field=...)` keyword args | `Q(email__icontains='x')` |
| `F('field')` first positional arg | `F('email')` |

### Out of scope (separate issues)

- Raw SQL / cursor.execute (#73)
- Rails symbol/hash-based references (#72)

## Test plan

- [x] `TestScanStringRefs_*` — 12 new unit tests covering all patterns and edge cases
- [x] `TestScanDjango_*` — merge, sort, and error-path tests
- [x] All existing tests pass (unit + e2e)
- [x] Coverage maintained at 100%