### PR TITLE
ci: run e2e tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,17 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage.out
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run e2e tests
+        run: make test-e2e


### PR DESCRIPTION
## Summary

- Add a dedicated `e2e` job to `test.yml` that runs `make test-e2e`
- `make test-e2e` builds the binary, runs the e2e suite, then cleans up automatically
- e2e coverage is intentionally excluded from the Codecov upload

Closes #103