### PR TITLE
ci: enforce 100% coverage threshold in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_THRESHOLD: 100
 
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +33,12 @@ jobs:
         run: |
           total=$(go tool cover -func=coverage.out | grep '^total' | awk '{print $3}' | tr -d '%')
           echo "Total coverage: ${total}%"
-          if ! awk "BEGIN { exit !(${total} >= 100) }"; then
-            echo "FAIL: coverage ${total}% is below threshold 100%"
+          if [ -z "$total" ]; then
+            echo "FAIL: could not parse coverage output"
+            exit 1
+          fi
+          if ! awk -v total="$total" -v threshold="$COVERAGE_THRESHOLD" 'BEGIN { exit !(total >= threshold) }'; then
+            echo "FAIL: coverage ${total}% is below threshold ${COVERAGE_THRESHOLD}%"
             exit 1
           fi
           echo "Coverage OK."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Run tests
         run: go test -race -coverprofile=coverage.out $(go list ./... | grep -v /e2e)
 
+      - name: Enforce coverage threshold
+        run: |
+          total=$(go tool cover -func=coverage.out | grep '^total' | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: ${total}%"
+          if ! awk "BEGIN { exit !(${total} >= 100) }"; then
+            echo "FAIL: coverage ${total}% is below threshold 100%"
+            exit 1
+          fi
+          echo "Coverage OK."
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary

- Add an "Enforce coverage threshold" step between `go test` and the Codecov upload
- Reads the already-generated `coverage.out` — tests are not run twice, `-race` detection is preserved
- Fails the job if total coverage drops below 100%, matching the pre-push hook behaviour

Closes #106