### PR TITLE
test(rails): add synthetic pattern battery fixture (#100)

### DIFF
--- a/test_patterns/rails/app/models/article.rb
+++ b/test_patterns/rails/app/models/article.rb
@@ -1,0 +1,8 @@
+class Article < ApplicationRecord
+  belongs_to :author
+
+  validates :title, presence: true
+  validates :slug, presence: true, uniqueness: true
+
+  scope :titled, ->(t) { where(title: t) }
+end

--- a/test_patterns/rails/app/serializers/article_serializer.rb
+++ b/test_patterns/rails/app/serializers/article_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :title, :slug                              # AMS attributes
+end

--- a/test_patterns/rails/db/schema.rb
+++ b/test_patterns/rails/db/schema.rb
@@ -1,0 +1,13 @@
+ActiveRecord::Schema[7.0].define(version: 2024_01_01_000000) do
+  create_table "authors", force: :cascade do |t|
+    t.string "name", null: false
+  end
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "slug", null: false
+    t.string "email"
+    t.string "status"
+    t.integer "author_id"
+  end
+end

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -1,8 +1,11 @@
 # Synthetic pattern battery for Article#title field reference detection.
-# Each pattern is on its own line for precise line-level verification.
-# Wrapped in a method so this file is safe to load without side effects.
+# Some patterns span multiple lines (e.g. multi-line chain).
+# Wrapped in `if false` so this file is safe to load without side effects.
 
-def _patterns(article, value)
+if false
+  article = nil
+  value   = nil
+
   # ── Attribute access — read ─────────────────────────────────────────────────
   x = article.title                                     # direct access
   x = Article.find(1).title                             # chained call

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -1,0 +1,76 @@
+# Synthetic pattern battery for Article#title field reference detection.
+# Each pattern is on its own line for precise line-level verification.
+# Wrapped in a method so this file is safe to load without side effects.
+
+def _patterns(article, value)
+  # ── Attribute access — read ─────────────────────────────────────────────────
+  x = article.title                                     # direct access
+  x = Article.find(1).title                             # chained call
+  x = Article.where(published: true)
+             .first
+             .title                                     # multi-line chain
+  x = "#{article.title}"                                # string interpolation
+  x = article&.title                                    # safe navigation
+
+  # ── Attribute access — write ─────────────────────────────────────────────────
+  article.title = value                                 # setter
+
+  # ── Hash / symbol access ─────────────────────────────────────────────────────
+  x = article[:title]                                   # symbol subscript
+  x = article.read_attribute(:title)                    # read_attribute
+  article.write_attribute(:title, value)                # write_attribute
+  x = article.send(:title)                              # send with symbol
+  x = article.public_send(:title)                       # public_send
+
+  # ── ActiveRecord — creation ───────────────────────────────────────────────────
+  a = Article.new(title: value)                         # new
+  a = Article.create(title: value)                      # create
+  a = Article.find_or_create_by(title: value)           # find_or_create_by
+  a = Article.find_or_initialize_by(title: value)       # find_or_initialize_by
+
+  # ── ActiveRecord — instance update ───────────────────────────────────────────
+  article.update(title: value)                          # update
+  article.assign_attributes(title: value)               # assign_attributes
+  article.update_column(:title, value)                  # update_column symbol
+  article.update_columns(title: value)                  # update_columns hash
+
+  # ── ActiveRecord — query methods ─────────────────────────────────────────────
+  Article.where(title: value)                           # where hash
+  Article.where("title = ?", value)                     # where string
+  Article.where.not(title: value)                       # where.not
+  Article.find_by(title: value)                         # find_by
+  Article.exists?(title: value)                         # exists?
+  Article.order(:title)                                 # order symbol
+  Article.order(title: :desc)                           # order hash
+  Article.order("title ASC")                            # order string
+  Article.pluck(:title)                                 # pluck symbol
+  Article.pluck("title")                                # pluck string
+  Article.select(:title)                                # select symbol
+  Article.select("title, slug")                         # select string
+  Article.group(:title)                                 # group symbol
+  Article.pick(:title)                                  # pick
+  Article.reorder(:title)                               # reorder
+  Article.update_all(title: value)                      # update_all
+
+  # ── ActiveRecord — aggregation ────────────────────────────────────────────────
+  Article.minimum(:title)                               # minimum
+  Article.maximum(:title)                               # maximum
+  Article.sum(:title)                                   # sum
+
+  # ── Arel ──────────────────────────────────────────────────────────────────────
+  t = Article.arel_table[:title]                        # table subscript
+  Article.arel_table[:title].eq(value)                  # arel condition
+
+  # ── Model declarations ────────────────────────────────────────────────────────
+  # (see app/models/article.rb for validates and scope patterns)
+
+  # ── Serialization / presentation ─────────────────────────────────────────────
+  params.require(:article).permit(:title, :slug)        # strong params permit
+  attributes :title, :slug                              # AMS attributes
+
+  # ── Dynamic / metaprogramming ─────────────────────────────────────────────────
+  article.respond_to?(:title)                           # respond_to?
+  article.instance_variable_get(:@title)               # instance_variable_get (not detectable)
+  article.title_changed?                                # attribute_changed? (name-mangled)
+  Article.find_by_title(value)                          # dynamic finder (name-mangled)
+end

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -6,7 +6,7 @@ def _patterns(article, value)
   # ── Attribute access — read ─────────────────────────────────────────────────
   x = article.title                                     # direct access
   x = Article.find(1).title                             # chained call
-  x = Article.where(published: true)
+  x = Article.where(status: 'published')
              .first
              .title                                     # multi-line chain
   x = "#{article.title}"                                # string interpolation
@@ -66,7 +66,7 @@ def _patterns(article, value)
 
   # ── Serialization / presentation ─────────────────────────────────────────────
   params.require(:article).permit(:title, :slug)        # strong params permit
-  attributes :title, :slug                              # AMS attributes
+  # AMS attributes: see app/serializers/article_serializer.rb
 
   # ── Dynamic / metaprogramming ─────────────────────────────────────────────────
   article.respond_to?(:title)                           # respond_to?


### PR DESCRIPTION
## Summary

- Add `test_patterns/rails/db/schema.rb` — articles + authors tables
- Add `test_patterns/rails/app/models/article.rb` — Article model with validates/scope declarations
- Add `test_patterns/rails/references.rb` — exhaustive reference to every known Ruby/Rails pattern for attribute access

## Coverage

Covers all pattern categories from #100: attribute access (read/write/safe-nav), hash/symbol access, ActiveRecord creation/update/query/aggregation, Arel, model declarations, serialization, and dynamic metaprogramming.

## Test plan

- [x] Run `colref check --orm rails --model Article --field title test_patterns/rails` — results documented in issue #100 comment
- [x] All existing tests pass, coverage at 100%

Closes #100