### PR TITLE
test: add golden-file e2e tests for Django and Rails pattern battery (#116)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -246,3 +246,25 @@ func TestE2E_MissingFlags(t *testing.T) {
 		assertContains(t, out, "field")
 	})
 }
+
+func TestE2E_PatternBattery_Django(t *testing.T) {
+	out, _ := run(t, "check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
+	golden, err := os.ReadFile("../test_patterns/django/golden_title.txt")
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+	if !bytes.Equal(out, golden) {
+		t.Errorf("output differs from golden\ngot:\n%s\nwant:\n%s", out, golden)
+	}
+}
+
+func TestE2E_PatternBattery_Rails(t *testing.T) {
+	out, _ := run(t, "check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
+	golden, err := os.ReadFile("../test_patterns/rails/golden_title.txt")
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+	if !bytes.Equal(out, golden) {
+		t.Errorf("output differs from golden\ngot:\n%s\nwant:\n%s", out, golden)
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -248,7 +248,10 @@ func TestE2E_MissingFlags(t *testing.T) {
 }
 
 func TestE2E_PatternBattery_Django(t *testing.T) {
-	out, _ := run(t, "check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
+	out, err := run(t, "check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+	}
 	golden, err := os.ReadFile("../test_patterns/django/golden_title.txt")
 	if err != nil {
 		t.Fatalf("failed to read golden file: %v", err)
@@ -259,7 +262,10 @@ func TestE2E_PatternBattery_Django(t *testing.T) {
 }
 
 func TestE2E_PatternBattery_Rails(t *testing.T) {
-	out, _ := run(t, "check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
+	out, err := run(t, "check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+	}
 	golden, err := os.ReadFile("../test_patterns/rails/golden_title.txt")
 	if err != nil {
 		t.Fatalf("failed to read golden file: %v", err)

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -1,0 +1,24 @@
+Scanning 2 files...
+
+References found for Article.title
+
+  references.py:30   article.title
+  references.py:31   qs.first().title
+  references.py:34   .title)                                            # multi-line chain
+  references.py:35   article.title
+  references.py:36   article.title
+  references.py:37   a.title
+  references.py:40   article.title
+  references.py:41   article.title
+  references.py:50   [string] qs = Article.objects.filter(title='x')                 # filter keyword
+  references.py:51   [string] qs = Article.objects.filter(title__icontains='x')      # filter lookup
+  references.py:52   [string] qs = Article.objects.exclude(title='x')                # exclude
+  references.py:56   [string] qs = Article.objects.filter(Q(title='x'))              # Q()
+  references.py:57   [string] qs = Article.objects.filter(Q(title__in=['x']))        # Q() with lookup
+  references.py:60   [string] qs = Article.objects.values('title')                   # values
+  references.py:61   [string] qs = Article.objects.values_list('title', flat=True)   # values_list
+  references.py:62   [string] qs = Article.objects.only('title')                     # only
+  references.py:63   [string] qs = Article.objects.defer('title')                    # defer
+  references.py:64   [string] qs = Article.objects.order_by('title')                 # order_by asc
+  references.py:74   [string] expr = F('title')                                       # F()
+  references.py:75   [string] qs = Article.objects.annotate(t=F('title'))            # annotate with F

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -1,0 +1,10 @@
+Scanning 4 files...
+
+References found for Article.title
+
+  references.rb:10   article.title
+  references.rb:11   Article.find(1).title
+  references.rb:14   .title                                     # multi-line chain
+  references.rb:15   article.title
+  references.rb:16   article&.title
+  references.rb:19   article.title


### PR DESCRIPTION
## Summary

- Add `test_patterns/django/golden_title.txt` and `test_patterns/rails/golden_title.txt` capturing current colref output for `Article.title` against each fixture
- Add `TestE2E_PatternBattery_Django` and `TestE2E_PatternBattery_Rails` in `e2e/e2e_test.go` that byte-compare colref output against the golden files

## How it works

Each test runs `colref check` against the pattern battery fixture and compares the output byte-for-byte to the committed golden file. If detection changes (regression or improvement), the test fails with a diff.

When detection coverage expands (e.g. after #110, #111), regenerate the golden files in the same PR:

```bash
make build
./colref check --orm django --model Article --field title test_patterns/django > test_patterns/django/golden_title.txt
./colref check --orm rails  --model Article --field title test_patterns/rails  > test_patterns/rails/golden_title.txt
```

## Test plan

- [x] `TestE2E_PatternBattery_Django` passes
- [x] `TestE2E_PatternBattery_Rails` passes
- [x] `make test-e2e` passes locally
- [x] All existing e2e tests pass

Closes #116