### PR TITLE
fix(django): detect order_by with descending prefix (-field)

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -339,8 +339,14 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 				case positionalStringMethods[methodName]:
 					for i := 0; i < int(args.ChildCount()); i++ {
 						child := args.Child(i)
-						if child.Type() == "string" && strings.TrimPrefix(stringContent(child, src), "-") == fieldName {
-							addStringRef(child, lines, file, refs)
+						if child.Type() == "string" {
+							content := stringContent(child, src)
+							if methodName == "order_by" {
+								content = strings.TrimPrefix(content, "-")
+							}
+							if content == fieldName {
+								addStringRef(child, lines, file, refs)
+							}
 						}
 					}
 				case keywordArgMethods[methodName]:

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -339,7 +339,7 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 				case positionalStringMethods[methodName]:
 					for i := 0; i < int(args.ChildCount()); i++ {
 						child := args.Child(i)
-						if child.Type() == "string" && stringContent(child, src) == fieldName {
+						if child.Type() == "string" && strings.TrimPrefix(stringContent(child, src), "-") == fieldName {
 							addStringRef(child, lines, file, refs)
 						}
 					}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -618,6 +618,19 @@ func TestScanStringRefs_OrderBy(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_OrderByDescending(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = User.objects.order_by("-email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for order_by descending, got %d: %v", len(refs), refs)
+	}
+}
+
 func TestScanStringRefs_QObject(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "views.py", `from django.db.models import Q; qs = User.objects.filter(Q(email="x"))`)

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -20,5 +20,6 @@ References found for Article.title
   references.py:62   [string] qs = Article.objects.only('title')                     # only
   references.py:63   [string] qs = Article.objects.defer('title')                    # defer
   references.py:64   [string] qs = Article.objects.order_by('title')                 # order_by asc
+  references.py:65   [string] qs = Article.objects.order_by('-title')                # order_by desc
   references.py:74   [string] expr = F('title')                                       # F()
   references.py:75   [string] qs = Article.objects.annotate(t=F('title'))            # annotate with F


### PR DESCRIPTION
## Summary

- Strip leading `-` from string content before comparing to `fieldName` in the `positionalStringMethods` branch of `walkNodeStringRefs`
- `order_by('-title')` is now detected and reported as `[string]`
- `order_by('title')` continues to work correctly

## Changes

- `internal/scanner/scanner.go`: use `strings.TrimPrefix(content, "-")` before comparing in `positionalStringMethods` case
- `internal/scanner/scanner_test.go`: add `TestScanStringRefs_OrderByDescending` unit test
- `test_patterns/django/golden_title.txt`: add expected line for `order_by('-title')` to pattern battery golden file

## Test plan

- [x] `TestScanStringRefs_OrderBy` — ascending case still passes
- [x] `TestScanStringRefs_OrderByDescending` — new test for descending case passes
- [x] `TestE2E_PatternBattery_Django` — golden file updated and passes
- [x] All tests pass with 100% coverage

Closes #109