### PR TITLE
feat(django): detect string refs in get/create/update/get_or_create/latest/earliest/distinct

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -92,12 +92,14 @@ func Scan(dir, fieldName string) ([]Reference, int, error) {
 var positionalStringMethods = map[string]bool{
 	"values": true, "values_list": true, "defer": true, "only": true,
 	"order_by": true, "select_related": true, "prefetch_related": true,
+	"latest": true, "earliest": true, "distinct": true,
 }
 
 // keywordArgMethods are Django ORM methods (and Q) whose keyword argument names
 // refer to model fields (possibly with lookup suffixes like __icontains).
 var keywordArgMethods = map[string]bool{
 	"filter": true, "exclude": true, "annotate": true, "Q": true,
+	"get": true, "create": true, "update": true, "get_or_create": true,
 }
 
 // ScanStringRefs walks dir and returns every string-based Django ORM reference

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -821,6 +821,12 @@ func TestScanStringRefs_Get(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for get(), got %d: %v", len(refs), refs)
 	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
 }
 
 func TestScanStringRefs_Create(t *testing.T) {
@@ -833,6 +839,12 @@ func TestScanStringRefs_Create(t *testing.T) {
 	}
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for create(), got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
 	}
 }
 
@@ -847,6 +859,12 @@ func TestScanStringRefs_Update(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for update(), got %d: %v", len(refs), refs)
 	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
 }
 
 func TestScanStringRefs_GetOrCreate(t *testing.T) {
@@ -859,6 +877,12 @@ func TestScanStringRefs_GetOrCreate(t *testing.T) {
 	}
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for get_or_create(), got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
 	}
 }
 
@@ -873,6 +897,12 @@ func TestScanStringRefs_Latest(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for latest(), got %d: %v", len(refs), refs)
 	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
 }
 
 func TestScanStringRefs_Earliest(t *testing.T) {
@@ -886,6 +916,12 @@ func TestScanStringRefs_Earliest(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for earliest(), got %d: %v", len(refs), refs)
 	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
 }
 
 func TestScanStringRefs_Distinct(t *testing.T) {
@@ -898,6 +934,12 @@ func TestScanStringRefs_Distinct(t *testing.T) {
 	}
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref for distinct(), got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
 	}
 }
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -810,6 +810,97 @@ func TestScanStringRefs_EmptyStringArgNoMatch(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_Get(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `obj = User.objects.get(email='x')`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for get(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_Create(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `obj = User.objects.create(email='x')`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for create(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_Update(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `User.objects.update(email='x')`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for update(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_GetOrCreate(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `obj, _ = User.objects.get_or_create(email='x')`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for get_or_create(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_Latest(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `obj = Article.objects.latest('title')`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for latest(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_Earliest(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `obj = Article.objects.earliest('title')`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for earliest(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_Distinct(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `qs = Article.objects.distinct('title')`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for distinct(), got %d: %v", len(refs), refs)
+	}
+}
+
 func TestScanRuby_BasicMatch(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "app.rb", `

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -13,6 +13,8 @@ References found for Article.title
   references.py:50   [string] qs = Article.objects.filter(title='x')                 # filter keyword
   references.py:51   [string] qs = Article.objects.filter(title__icontains='x')      # filter lookup
   references.py:52   [string] qs = Article.objects.exclude(title='x')                # exclude
+  references.py:53   [string] obj = Article.objects.get(title='x')                   # get
+  references.py:54   [string] obj, _ = Article.objects.get_or_create(title='x')      # get_or_create
   references.py:56   [string] qs = Article.objects.filter(Q(title='x'))              # Q()
   references.py:57   [string] qs = Article.objects.filter(Q(title__in=['x']))        # Q() with lookup
   references.py:60   [string] qs = Article.objects.values('title')                   # values
@@ -21,5 +23,10 @@ References found for Article.title
   references.py:63   [string] qs = Article.objects.defer('title')                    # defer
   references.py:64   [string] qs = Article.objects.order_by('title')                 # order_by asc
   references.py:65   [string] qs = Article.objects.order_by('-title')                # order_by desc
+  references.py:67   [string] obj = Article.objects.latest('title')                  # latest
+  references.py:68   [string] obj = Article.objects.earliest('title')                # earliest
+  references.py:69   [string] qs = Article.objects.distinct('title')                 # distinct (PostgreSQL)
+  references.py:70   [string] obj = Article.objects.create(title='x')                # create
+  references.py:71   [string] Article.objects.update(title='x')                      # update (bulk)
   references.py:74   [string] expr = F('title')                                       # F()
   references.py:75   [string] qs = Article.objects.annotate(t=F('title'))            # annotate with F


### PR DESCRIPTION
## Summary

Add 7 missing Django ORM methods to the scanner's whitelist so their field-name arguments are detected as `[string]` references.

**Added to `keywordArgMethods`** (keyword args whose names are field references, same structure as `filter`/`exclude`):
- `get` — `.get(title='x')`
- `create` — `.create(title='x')`
- `update` — `.update(title='x')`
- `get_or_create` — `.get_or_create(title='x')`

**Added to `positionalStringMethods`** (positional string args that name a field, same structure as `only`/`defer`):
- `latest` — `.latest('title')`
- `earliest` — `.earliest('title')`
- `distinct` — `.distinct('title')` (PostgreSQL)

Note: `update_or_create` uses `defaults={'field': value}` — a nested dict pattern — and remains out of scope.

## Test plan

- [x] Unit test added for each of the 7 new methods
- [x] `TestE2E_PatternBattery_Django` golden file updated and passes
- [x] All tests pass with 100% coverage

Closes #110