### PR TITLE
refactor(cmd): split main.go into root.go and check.go

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -12,7 +12,38 @@ import (
 	"github.com/shinagawa-web/colref/internal/orm"
 	"github.com/shinagawa-web/colref/internal/parser"
 	"github.com/shinagawa-web/colref/internal/scanner"
+	"github.com/spf13/cobra"
 )
+
+var (
+	flagModel string
+	flagField string
+	flagOrm   string
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check [path]",
+	Short: "Scan a codebase for references to a model field",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := "."
+		if len(args) == 1 {
+			dir = args[0]
+		}
+		return runCheck(dir, flagModel, flagField, flagOrm)
+	},
+}
+
+func init() {
+	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
+	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
+	checkCmd.Flags().StringVar(&flagOrm, "orm", "", "ORM type: django, rails")
+	_ = checkCmd.MarkFlagRequired("model")
+	_ = checkCmd.MarkFlagRequired("field")
+	_ = checkCmd.MarkFlagRequired("orm")
+
+	rootCmd.AddCommand(checkCmd)
+}
 
 // buildModelSet is the function used to build the cross-file Django model set.
 // It is a var so tests can inject a failing version to cover error paths.

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var exit = os.Exit
@@ -14,41 +12,4 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 	}
-}
-
-var rootCmd = &cobra.Command{
-	Use:           "colref",
-	Short:         "Check whether a DB column is still referenced before you delete it",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-}
-
-var (
-	flagModel string
-	flagField string
-	flagOrm   string
-)
-
-var checkCmd = &cobra.Command{
-	Use:   "check [path]",
-	Short: "Scan a codebase for references to a model field",
-	Args:  cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dir := "."
-		if len(args) == 1 {
-			dir = args[0]
-		}
-		return runCheck(dir, flagModel, flagField, flagOrm)
-	},
-}
-
-func init() {
-	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
-	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
-	checkCmd.Flags().StringVar(&flagOrm, "orm", "", "ORM type: django, rails")
-	_ = checkCmd.MarkFlagRequired("model")
-	_ = checkCmd.MarkFlagRequired("field")
-	_ = checkCmd.MarkFlagRequired("orm")
-
-	rootCmd.AddCommand(checkCmd)
 }

--- a/cmd/colref/main_test.go
+++ b/cmd/colref/main_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-func TestMain_Success(t *testing.T) {
-	// --help is handled by cobra and returns nil from Execute.
-	rootCmd.SetOut(io.Discard)
-	rootCmd.SetErr(io.Discard)
-	rootCmd.SetArgs([]string{"--help"})
-	main()
-}
-
 func TestMain_Error(t *testing.T) {
 	origExit := exit
 	var code int

--- a/cmd/colref/root.go
+++ b/cmd/colref/root.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var rootCmd = &cobra.Command{
+	Use:           "colref",
+	Short:         "Check whether a DB column is still referenced before you delete it",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}

--- a/cmd/colref/root_test.go
+++ b/cmd/colref/root_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"io"
+	"testing"
+)
+
+func TestRootCmd_Help(t *testing.T) {
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{"--help"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Move `rootCmd` into a new `root.go` file
- Move `checkCmd`, flag variables, and `init()` from `main.go` into `check.go`
- `main.go` now contains only the entry point (`main` + `exit`)

## Test plan

- [x] `go build` passes
- [x] All unit tests pass (`go test ./...`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage remains 100%
- [x] `golangci-lint` reports 0 issues