### PR TITLE
feat(django): detect string refs in aggregate and expression functions

### DIFF
--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -30,11 +30,11 @@ var positionalStringMethods = map[string]bool{
 // firstArgStringFunctions are Django expression/aggregate functions whose first
 // positional string argument is a field name (same convention as F()).
 var firstArgStringFunctions = map[string]bool{
-	"F":        true,
-	"Max":      true, "Min": true, "Avg": true, "Sum": true, "Count": true,
-	"StdDev":   true, "Variance": true,
+	"F":   true,
+	"Max": true, "Min": true, "Avg": true, "Sum": true, "Count": true,
+	"StdDev": true, "Variance": true,
 	"Coalesce": true, "Concat": true, "Greatest": true, "Least": true,
-	"NullIf":   true, "OuterRef": true, "Subquery": true,
+	"NullIf": true, "OuterRef": true, "Subquery": true,
 }
 
 // keywordArgMethods are Django ORM methods (and Q) whose keyword argument names

--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -27,6 +27,16 @@ var positionalStringMethods = map[string]bool{
 	"latest": true, "earliest": true, "distinct": true,
 }
 
+// firstArgStringFunctions are Django expression/aggregate functions whose first
+// positional string argument is a field name (same convention as F()).
+var firstArgStringFunctions = map[string]bool{
+	"F":        true,
+	"Max":      true, "Min": true, "Avg": true, "Sum": true, "Count": true,
+	"StdDev":   true, "Variance": true,
+	"Coalesce": true, "Concat": true, "Greatest": true, "Least": true,
+	"NullIf":   true, "OuterRef": true, "Subquery": true,
+}
+
 // keywordArgMethods are Django ORM methods (and Q) whose keyword argument names
 // refer to model fields (possibly with lookup suffixes like __icontains).
 var keywordArgMethods = map[string]bool{
@@ -95,7 +105,7 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 			args := node.ChildByFieldName("arguments")
 			if args != nil {
 				switch {
-				case methodName == "F":
+				case firstArgStringFunctions[methodName]:
 					for i := 0; i < int(args.ChildCount()); i++ {
 						child := args.Child(i)
 						if child.Type() == "string" {

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1484,6 +1484,79 @@ func TestScanRuby_ERBStringLiteralWithPercentGT(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_Max(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `from django.db.models import Max; result = Article.objects.aggregate(Max("title"))`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for Max(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_AggregateVariants(t *testing.T) {
+	for _, fn := range []string{"Min", "Avg", "Sum", "Count", "StdDev", "Variance"} {
+		fn := fn
+		t.Run(fn, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "views.py", `result = Article.objects.aggregate(`+fn+`("title"))`)
+			refs, _, err := ScanStringRefs(dir, "title")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(refs) != 1 {
+				t.Fatalf("%s: want 1 ref, got %d: %v", fn, len(refs), refs)
+			}
+		})
+	}
+}
+
+func TestScanStringRefs_Coalesce(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `from django.db.models.functions import Coalesce; expr = Coalesce("title", Value(""))`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for Coalesce(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_OuterRef(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `from django.db.models import OuterRef; expr = OuterRef("title")`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for OuterRef(), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_ExpressionVariants(t *testing.T) {
+	for _, fn := range []string{"Concat", "Greatest", "Least", "NullIf", "Subquery"} {
+		fn := fn
+		t.Run(fn, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "views.py", `expr = `+fn+`("title")`)
+			refs, _, err := ScanStringRefs(dir, "title")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(refs) != 1 {
+				t.Fatalf("%s: want 1 ref, got %d: %v", fn, len(refs), refs)
+			}
+		})
+	}
+}
+
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
 // per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
 // in line density while exceeding it in file count.

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -30,3 +30,7 @@ References found for Article.title
   references.py:71   [string] Article.objects.update(title='x')                      # update (bulk)
   references.py:74   [string] expr = F('title')                                       # F()
   references.py:75   [string] qs = Article.objects.annotate(t=F('title'))            # annotate with F
+  references.py:76   [string] x = Article.objects.aggregate(Max('title'))            # aggregate
+  references.py:77   [string] expr = Coalesce('title', Value(''))                    # Coalesce
+  references.py:78   [string] expr = Concat('title', Value(' - '))                   # Concat
+  references.py:79   [string] expr = OuterRef('title')                               # OuterRef


### PR DESCRIPTION
## Summary

- Replace the single `methodName == "F"` branch with a `firstArgStringFunctions` map
- Adds detection for aggregate functions: `Max`, `Min`, `Avg`, `Sum`, `Count`, `StdDev`, `Variance`
- Adds detection for expression functions: `Coalesce`, `Concat`, `Greatest`, `Least`, `NullIf`, `OuterRef`, `Subquery`
- `F()` behaviour unchanged

## Test plan

- [x] Unit tests added for `Max`, all aggregate variants, `Coalesce`, `OuterRef`, all expression variants
- [x] Pattern battery golden file updated with 4 new detections (lines 76–79)
- [x] All tests pass with 100% coverage
- [x] `golangci-lint` reports 0 issues

Closes #111