### PR TITLE
feat(rails): extend string-based ORM detection to creation, update, and aggregation

### DIFF
--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -24,6 +24,8 @@ var RubySkipDirs = map[string]bool{
 var rubySymbolArgMethods = map[string]bool{
 	"select": true, "order": true, "pluck": true,
 	"pick": true, "group": true, "reorder": true,
+	"update_column": true,
+	"minimum":       true, "maximum": true, "sum": true,
 }
 
 // rubyHashKeyArgMethods are ActiveRecord methods that accept field names as
@@ -31,6 +33,9 @@ var rubySymbolArgMethods = map[string]bool{
 // time to avoid matching unrelated DSL methods.
 var rubyHashKeyArgMethods = map[string]bool{
 	"where": true, "order": true, "reorder": true, "not": true,
+	"new": true, "create": true, "find_or_create_by": true, "find_or_initialize_by": true,
+	"update": true, "assign_attributes": true, "update_columns": true, "update_all": true,
+	"find_by": true, "exists?": true,
 }
 
 // RubyScanner implements orm.ReferenceScanner for Ruby codebases.

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2129,3 +2129,173 @@ func TestScanRubyStringRefs_FieldAfterEmbeddedOccurrence(t *testing.T) {
 		t.Fatalf("want 1 ref (second occurrence matches), got %d: %v", len(refs), refs)
 	}
 }
+
+// ── Rails string refs — creation, update, aggregation (issue #118) ──────────
+
+func TestScanRubyStringRefs_New(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.new(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.new(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Create(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.create(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.create(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_FindOrCreateBy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.find_or_create_by(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.find_or_create_by(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_FindOrInitializeBy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.find_or_initialize_by(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.find_or_initialize_by(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Update(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `record.update(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] record.update(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AssignAttributes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `record.assign_attributes(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] record.assign_attributes(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_UpdateColumn(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `record.update_column(:email, value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] record.update_column(:email, value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_UpdateColumns(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `record.update_columns(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] record.update_columns(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_UpdateAll(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.update_all(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.update_all(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_FindBy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.find_by(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.find_by(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_ExistsQ(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.exists?(email: value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.exists?(email: value)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Minimum(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.minimum(:email)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.minimum(:email)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Maximum(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.maximum(:email)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.maximum(:email)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Sum(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.sum(:email)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.sum(:email)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -9,9 +9,19 @@ References found for Article.title
   references.rb:15          article.title
   references.rb:16          article&.title
   references.rb:19          article.title
+  references.rb:29          [string] a = Article.new(title: value)                         # new
+  references.rb:30          [string] a = Article.create(title: value)                      # create
+  references.rb:31          [string] a = Article.find_or_create_by(title: value)           # find_or_create_by
+  references.rb:32          [string] a = Article.find_or_initialize_by(title: value)       # find_or_initialize_by
+  references.rb:35          [string] article.update(title: value)                          # update
+  references.rb:36          [string] article.assign_attributes(title: value)               # assign_attributes
+  references.rb:37          [string] article.update_column(:title, value)                  # update_column symbol
+  references.rb:38          [string] article.update_columns(title: value)                  # update_columns hash
   references.rb:41          [string] Article.where(title: value)                           # where hash
   references.rb:42          [sql ref] Article.where("title = ?", value)                     # where string
   references.rb:43          [string] Article.where.not(title: value)                       # where.not
+  references.rb:44          [string] Article.find_by(title: value)                         # find_by
+  references.rb:45          [string] Article.exists?(title: value)                         # exists?
   references.rb:46          [string] Article.order(:title)                                 # order symbol
   references.rb:47          [string] Article.order(title: :desc)                           # order hash
   references.rb:48          [sql ref] Article.order("title ASC")                            # order string
@@ -22,5 +32,9 @@ References found for Article.title
   references.rb:53          [string] Article.group(:title)                                 # group symbol
   references.rb:54          [string] Article.pick(:title)                                  # pick
   references.rb:55          [string] Article.reorder(:title)                               # reorder
+  references.rb:56          [string] Article.update_all(title: value)                      # update_all
+  references.rb:59          [string] Article.minimum(:title)                               # minimum
+  references.rb:60          [string] Article.maximum(:title)                               # maximum
+  references.rb:61          [string] Article.sum(:title)                                   # sum
   references.rb:64          [string] t = Article.arel_table[:title]                        # table subscript
   references.rb:65          [string] Article.arel_table[:title].eq(value)                  # arel condition


### PR DESCRIPTION
## Summary

Closes #118. Extends the symbol/hash-key detection from #72 to cover the remaining ActiveRecord method families confirmed missing in the pattern battery.

**New methods added:**

| Family | Methods | Pattern | Label |
|--------|---------|---------|-------|
| Creation | `new`, `create`, `find_or_create_by`, `find_or_initialize_by` | `Model.new(field: v)` | `[string]` |
| Update | `update`, `assign_attributes`, `update_columns`, `update_all` | `record.update(field: v)` | `[string]` |
| Update | `update_column` | `record.update_column(:field, v)` | `[string]` |
| Query | `find_by`, `exists?` | `Model.find_by(field: v)` | `[string]` |
| Aggregation | `minimum`, `maximum`, `sum` | `Model.minimum(:field)` | `[string]` |

## Implementation

Two-line change to the method maps in `rails.go`:
- `rubyHashKeyArgMethods`: +`new`, `create`, `find_or_create_by`, `find_or_initialize_by`, `update`, `assign_attributes`, `update_columns`, `update_all`, `find_by`, `exists?`
- `rubySymbolArgMethods`: +`update_column`, `minimum`, `maximum`, `sum`

## Test plan

- [x] 14 new unit tests (one per method)
- [x] `TestE2E_PatternBattery_Rails` passes with updated golden (23 → 37 detected refs)
- [x] 100% statement coverage maintained
- [x] `make static-lint` — 0 issues