### PR TITLE
feat(django): detect field references in raw SQL strings

### DIFF
--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -221,16 +221,26 @@ func addSqlRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference
 	})
 }
 
-// isSQLString reports whether s looks like a SQL DML statement by checking
-// that its trimmed prefix matches a known DML keyword.
+// isSQLString reports whether s looks like a SQL DML statement. The trimmed
+// prefix must match a known DML keyword followed by a non-word character (or
+// end of string), so strings like "SELECTED..." or "WITHDRAW..." are rejected.
 func isSQLString(s string) bool {
 	upper := strings.ToUpper(strings.TrimSpace(s))
 	for _, kw := range sqlDMLPrefixes {
 		if strings.HasPrefix(upper, kw) {
-			return true
+			rest := upper[len(kw):]
+			if len(rest) == 0 || !sqlWordByte(rest[0]) {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+// sqlWordByte reports whether b is an ASCII identifier character (letter,
+// digit, or underscore) used to enforce DML keyword boundaries.
+func sqlWordByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_'
 }
 
 // sqlParseCtxFn is the function used to parse SQL into a tree.
@@ -256,11 +266,17 @@ func sqlContainsField(sqlSrc []byte, fieldName string) bool {
 
 // walkSQLFieldNode recursively walks a SQL AST and returns true if any field
 // node contains an identifier child that equals fieldName.
+// Identifiers immediately preceded by '%' in the source are skipped; they are
+// DB-API positional placeholders (%s, %d, etc.) parsed as spurious field nodes.
 func walkSQLFieldNode(node *sitter.Node, src []byte, fieldName string) bool {
 	if node.Type() == "field" {
 		for i := 0; i < int(node.ChildCount()); i++ {
 			c := node.Child(i)
 			if c.Type() == "identifier" && c.Content(src) == fieldName {
+				start := int(c.StartByte())
+				if start > 0 && src[start-1] == '%' {
+					continue
+				}
 				return true
 			}
 		}

--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -1,11 +1,13 @@
 package refs
 
 import (
+	"context"
 	"sort"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
+	gosql "github.com/smacker/go-tree-sitter/sql"
 
 	"github.com/shinagawa-web/colref/internal/orm"
 )
@@ -43,6 +45,16 @@ var keywordArgMethods = map[string]bool{
 	"filter": true, "exclude": true, "annotate": true, "Q": true,
 	"get": true, "create": true, "update": true, "get_or_create": true,
 }
+
+// sqlMethods are Python methods whose first positional string argument is raw SQL.
+var sqlMethods = map[string]bool{
+	"raw": true, "execute": true,
+}
+
+// sqlDMLPrefixes are SQL DML keywords a raw SQL string must begin with
+// (case-insensitive) before we bother parsing it. This avoids feeding
+// arbitrary strings (e.g. log messages) to the SQL grammar.
+var sqlDMLPrefixes = []string{"SELECT", "INSERT", "UPDATE", "DELETE", "WITH"}
 
 // PythonScanner implements orm.ReferenceScanner for Python codebases.
 type PythonScanner struct{}
@@ -144,6 +156,17 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 							}
 						}
 					}
+				case sqlMethods[methodName]:
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() == "string" {
+							content := stringContent(child, src)
+							if isSQLString(content) && sqlContainsField([]byte(content), fieldName) {
+								addSqlRef(child, lines, file, refs)
+							}
+							break
+						}
+					}
 				}
 			}
 		}
@@ -186,6 +209,68 @@ func addStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Refere
 		Line: row + 1,
 		Text: "[string] " + strings.TrimSpace(lineAt(lines, row)),
 	})
+}
+
+// addSqlRef appends a [sql ref]-labeled Reference using the node's source row.
+func addSqlRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
+	row := int(node.StartPoint().Row)
+	*refs = append(*refs, Reference{
+		File: file,
+		Line: row + 1,
+		Text: "[sql ref] " + strings.TrimSpace(lineAt(lines, row)),
+	})
+}
+
+// isSQLString reports whether s looks like a SQL DML statement by checking
+// that its trimmed prefix matches a known DML keyword.
+func isSQLString(s string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(s))
+	for _, kw := range sqlDMLPrefixes {
+		if strings.HasPrefix(upper, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// sqlParseCtxFn is the function used to parse SQL into a tree.
+// It is a var so tests can inject a failing version to cover error paths.
+var sqlParseCtxFn = func(p *sitter.Parser, src []byte) (*sitter.Tree, error) {
+	return p.ParseCtx(context.Background(), nil, src)
+}
+
+// sqlContainsField reports whether fieldName appears as a SQL field identifier
+// in sqlSrc. The SQL is parsed with the tree-sitter SQL grammar; field nodes
+// whose identifier child matches fieldName trigger a true return.
+// Note: single-letter field names risk false positives from %s placeholders,
+// which the SQL grammar parses as (ERROR "%")(field "s").
+func sqlContainsField(sqlSrc []byte, fieldName string) bool {
+	p := sitter.NewParser()
+	p.SetLanguage(gosql.GetLanguage())
+	tree, err := sqlParseCtxFn(p, sqlSrc)
+	if err != nil || tree == nil {
+		return false
+	}
+	return walkSQLFieldNode(tree.RootNode(), sqlSrc, fieldName)
+}
+
+// walkSQLFieldNode recursively walks a SQL AST and returns true if any field
+// node contains an identifier child that equals fieldName.
+func walkSQLFieldNode(node *sitter.Node, src []byte, fieldName string) bool {
+	if node.Type() == "field" {
+		for i := 0; i < int(node.ChildCount()); i++ {
+			c := node.Child(i)
+			if c.Type() == "identifier" && c.Content(src) == fieldName {
+				return true
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		if walkSQLFieldNode(node.Child(i), src, fieldName) {
+			return true
+		}
+	}
+	return false
 }
 
 func walkNode(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1633,6 +1633,32 @@ func TestScanStringRefs_RawSQL_NonStringFirstArg(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_SQLDMLBoundary_NotMatched(t *testing.T) {
+	// "SELECTED..." starts with SELECT but is not a DML keyword (no word boundary).
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `cursor.execute("SELECTED title FROM articles")`)
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs for non-DML prefix, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_SQLPlaceholder_NotFalsePositive(t *testing.T) {
+	// Field name "s" must not match the "s" inside a %s placeholder.
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `cursor.execute("SELECT id FROM auth_user WHERE active = %s", [True])`)
+	refs, _, err := ScanStringRefs(dir, "s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs for %%s placeholder, got %d: %v", len(refs), refs)
+	}
+}
+
 func TestScanStringRefs_SQLParseError(t *testing.T) {
 	orig := sqlParseCtxFn
 	sqlParseCtxFn = func(_ *sitter.Parser, _ []byte) (*sitter.Tree, error) {

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1557,6 +1557,100 @@ func TestScanStringRefs_ExpressionVariants(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_RawSQL_Match(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `User.objects.raw("SELECT email FROM auth_user WHERE active = 1")`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[sql ref]") {
+		t.Errorf("want [sql ref] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_RawSQL_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `User.objects.raw("SELECT id FROM auth_user WHERE active = 1")`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_CursorExecute_Match(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `
+with connection.cursor() as cursor:
+    cursor.execute("SELECT email, name FROM auth_user WHERE active = %s", [True])
+`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Line != 3 {
+		t.Errorf("want line 3, got %d", refs[0].Line)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[sql ref]") {
+		t.Errorf("want [sql ref] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_NonSQLString_NotMatched(t *testing.T) {
+	dir := t.TempDir()
+	// "execute" with a non-SQL string should not be matched even if field name appears
+	writeFile(t, dir, "tasks.py", `task.execute("process email records")`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_RawSQL_NonStringFirstArg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `User.objects.raw(sql_var)`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_SQLParseError(t *testing.T) {
+	orig := sqlParseCtxFn
+	sqlParseCtxFn = func(_ *sitter.Parser, _ []byte) (*sitter.Tree, error) {
+		return nil, fmt.Errorf("injected SQL parse error")
+	}
+	defer func() { sqlParseCtxFn = orig }()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `User.objects.raw("SELECT email FROM auth_user")`)
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs on parse error, got %d", len(refs))
+	}
+}
+
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
 // per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
 // in line density while exceeding it in file count.

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -34,3 +34,5 @@ References found for Article.title
   references.py:77   [string] expr = Coalesce('title', Value(''))                    # Coalesce
   references.py:78   [string] expr = Concat('title', Value(' - '))                   # Concat
   references.py:79   [string] expr = OuterRef('title')                               # OuterRef
+  references.py:97   [sql ref] qs = Article.objects.raw("SELECT title FROM article WHERE slug = %s", [slug])  # raw()
+  references.py:99   [sql ref] cursor.execute("SELECT title, slug FROM article WHERE active = 1")         # cursor.execute

--- a/test_patterns/django/references.py
+++ b/test_patterns/django/references.py
@@ -92,3 +92,8 @@ if False:
 
     # ── Django forms ──────────────────────────────────────────────────────────
     form_fields = ['title']                                # ModelForm.Meta.fields
+
+    # ── Raw SQL ───────────────────────────────────────────────────────────────
+    qs = Article.objects.raw("SELECT title FROM article WHERE slug = %s", [slug])  # raw()
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT title, slug FROM article WHERE active = 1")         # cursor.execute


### PR DESCRIPTION
Closes #73

## Summary

- Parse the first positional string argument of `Manager.raw()` and `cursor.execute()` with the tree-sitter SQL grammar
- Walk `field` → `identifier` nodes in the SQL AST; emit a `[sql ref]` reference when the identifier matches the target field name
- A DML-prefix check (`SELECT|INSERT|UPDATE|DELETE|WITH`) gates SQL parsing, preventing non-SQL strings passed to generic `execute()` methods from being fed to the parser
- Static strings only; f-strings and concatenated SQL are out of scope

## Test plan

- `TestScanStringRefs_RawSQL_Match` — `raw()` with field in SELECT clause
- `TestScanStringRefs_RawSQL_NoMatch` — `raw()` with different field, no match
- `TestScanStringRefs_CursorExecute_Match` — `cursor.execute()` with field in SELECT and WHERE
- `TestScanStringRefs_NonSQLString_NotMatched` — non-SQL string to `execute()`, no match (DML prefix guard)
- `TestScanStringRefs_RawSQL_NonStringFirstArg` — non-string first arg, no match
- `TestScanStringRefs_SQLParseError` — injected SQL parse error returns no refs
- Golden file updated with two new `[sql ref]` entries in `test_patterns/django/`
- 100% statement coverage maintained