### PR TITLE
feat(rails): detect field references in raw SQL strings

### DIFF
--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -123,7 +123,42 @@ func walkNodeRuby(node *sitter.Node, src []byte, lines [][]byte, fieldName, file
 }
 
 // walkNodeRubyStringRefs finds string-based ActiveRecord references to fieldName.
+// It pre-collects the source rows of heredoc_beginning nodes inside rubySqlMethods
+// calls so that the heredoc_body handler only fires for SQL method arguments.
 func walkNodeRubyStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
+	sqlHeredocRows := collectSqlHeredocRows(node, src)
+	walkNodeRubyStringRefsInner(node, src, lines, fieldName, file, refs, sqlHeredocRows)
+}
+
+// collectSqlHeredocRows pre-scans the AST subtree rooted at root and returns
+// the set of source rows on which heredoc_beginning nodes appear as positional
+// arguments to rubySqlMethods calls. The heredoc_body sibling shares the same
+// StartPoint().Row, so this set is used to constrain the heredoc_body handler.
+func collectSqlHeredocRows(root *sitter.Node, src []byte) map[int]bool {
+	rows := make(map[int]bool)
+	var collect func(*sitter.Node)
+	collect = func(node *sitter.Node) {
+		if node.Type() == "call" {
+			method := node.ChildByFieldName("method")
+			args := node.ChildByFieldName("arguments")
+			if method != nil && args != nil && rubySqlMethods[method.Content(src)] {
+				for i := 0; i < int(args.ChildCount()); i++ {
+					c := args.Child(i)
+					if c.Type() == "heredoc_beginning" {
+						rows[int(c.StartPoint().Row)] = true
+					}
+				}
+			}
+		}
+		for i := 0; i < int(node.ChildCount()); i++ {
+			collect(node.Child(i))
+		}
+	}
+	collect(root)
+	return rows
+}
+
+func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference, sqlHeredocRows map[int]bool) {
 	switch node.Type() {
 	case "call":
 		method := node.ChildByFieldName("method")
@@ -211,6 +246,10 @@ func walkNodeRubyStringRefs(node *sitter.Node, src []byte, lines [][]byte, field
 		}
 
 	case "heredoc_body":
+		// Only emit a ref when this heredoc was passed to a rubySqlMethod call.
+		if !sqlHeredocRows[int(node.StartPoint().Row)] {
+			break
+		}
 		var sb strings.Builder
 		for i := 0; i < int(node.ChildCount()); i++ {
 			c := node.Child(i)
@@ -225,7 +264,7 @@ func walkNodeRubyStringRefs(node *sitter.Node, src []byte, lines [][]byte, field
 	}
 
 	for i := 0; i < int(node.ChildCount()); i++ {
-		walkNodeRubyStringRefs(node.Child(i), src, lines, fieldName, file, refs)
+		walkNodeRubyStringRefsInner(node.Child(i), src, lines, fieldName, file, refs, sqlHeredocRows)
 	}
 }
 
@@ -235,15 +274,17 @@ func rubySymbolName(node *sitter.Node, src []byte) string {
 	return node.Content(src)[1:]
 }
 
-// rubyStringContent returns the string_content child of a Ruby string node.
+// rubyStringContent returns the concatenated text of all string_content children
+// of a Ruby string node, skipping interpolations and other non-literal segments.
 func rubyStringContent(node *sitter.Node, src []byte) string {
+	var sb strings.Builder
 	for i := 0; i < int(node.ChildCount()); i++ {
 		c := node.Child(i)
 		if c.Type() == "string_content" {
-			return c.Content(src)
+			sb.WriteString(c.Content(src))
 		}
 	}
-	return ""
+	return sb.String()
 }
 
 // rubyContainsField reports whether s contains fieldName as a whole word

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -38,6 +38,12 @@ var rubyHashKeyArgMethods = map[string]bool{
 	"find_by": true, "exists?": true,
 }
 
+// rubySqlMethods are Ruby/ActiveRecord methods whose first positional string
+// argument is raw SQL.
+var rubySqlMethods = map[string]bool{
+	"find_by_sql": true, "execute": true, "select_all": true,
+}
+
 // RubyScanner implements orm.ReferenceScanner for Ruby codebases.
 type RubyScanner struct{}
 
@@ -127,6 +133,20 @@ func walkNodeRubyStringRefs(node *sitter.Node, src []byte, lines [][]byte, field
 		}
 		methodName := method.Content(src)
 
+		if rubySqlMethods[methodName] {
+			for i := 0; i < int(args.ChildCount()); i++ {
+				child := args.Child(i)
+				if child.Type() == "string" {
+					content := rubyStringContent(child, src)
+					if isSQLString(content) && sqlContainsField([]byte(content), fieldName) {
+						addRubySqlRef(child, lines, file, refs)
+					}
+					break
+				}
+			}
+			break
+		}
+
 		// For "not", only match when receiver is a call to "where".
 		if methodName == "not" {
 			receiver := node.ChildByFieldName("receiver")
@@ -188,6 +208,19 @@ func walkNodeRubyStringRefs(node *sitter.Node, src []byte, lines [][]byte, field
 					}
 				}
 			}
+		}
+
+	case "heredoc_body":
+		var sb strings.Builder
+		for i := 0; i < int(node.ChildCount()); i++ {
+			c := node.Child(i)
+			if c.Type() == "heredoc_content" {
+				sb.WriteString(c.Content(src))
+			}
+		}
+		content := sb.String()
+		if isSQLString(content) && sqlContainsField([]byte(content), fieldName) {
+			addRubySqlRef(node, lines, file, refs)
 		}
 	}
 

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2476,7 +2476,8 @@ func TestScanRubyStringRefs_SelectAll_StringArg(t *testing.T) {
 
 func TestScanRubyStringRefs_FindBySql_Heredoc_LineNumber(t *testing.T) {
 	// Verify the line number reported for a heredoc SQL argument.
-	// The heredoc_body node's StartPoint().Row determines what line we report.
+	// The heredoc_body node's StartPoint().Row equals the opener line row,
+	// so the reported line points to the find_by_sql call, not the SQL content.
 	src := "Article.find_by_sql(<<~SQL)\n  SELECT * FROM articles WHERE email = ?\nSQL\n"
 	dir := t.TempDir()
 	writeFile(t, dir, "app.rb", src)
@@ -2487,7 +2488,13 @@ func TestScanRubyStringRefs_FindBySql_Heredoc_LineNumber(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
 	}
-	t.Logf("heredoc ref: line=%d text=%q", refs[0].Line, refs[0].Text)
+	if refs[0].Line != 1 {
+		t.Errorf("want line 1 (call line), got %d", refs[0].Line)
+	}
+	wantText := `[sql ref] Article.find_by_sql(<<~SQL)`
+	if refs[0].Text != wantText {
+		t.Errorf("want text %q, got %q", wantText, refs[0].Text)
+	}
 }
 
 func TestScanRubyStringRefs_Heredoc_NoDMLPrefix_NotMatched(t *testing.T) {
@@ -2500,6 +2507,21 @@ func TestScanRubyStringRefs_Heredoc_NoDMLPrefix_NotMatched(t *testing.T) {
 	}
 	if len(refs) != 0 {
 		t.Errorf("expected no refs for non-SQL heredoc, got %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Heredoc_NonSqlMethod_Ignored(t *testing.T) {
+	// A heredoc passed to a non-SQL method (e.g. plain assignment) that happens
+	// to contain a SQL DML keyword must not produce a [sql ref].
+	src := "body = <<~SQL\n  SELECT * FROM articles WHERE email = ?\nSQL\n"
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", src)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected no refs for heredoc not passed to SQL method, got %v", refs)
 	}
 }
 

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2419,3 +2419,99 @@ func TestScanRubyStringRefs_Sum(t *testing.T) {
 		t.Errorf("unexpected refs: %v", refs)
 	}
 }
+
+// ── Rails raw SQL reference tests ────────────────────────────────────────────
+
+func TestScanRubyStringRefs_FindBySql_StringArg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.find_by_sql("SELECT * FROM articles WHERE email = ?", value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	want := `[sql ref] Article.find_by_sql("SELECT * FROM articles WHERE email = ?", value)`
+	if refs[0].Text != want {
+		t.Errorf("unexpected text: %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_FindBySql_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.find_by_sql("SELECT * FROM articles WHERE name = ?", value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected no refs, got %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Execute_StringArg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `connection.execute("UPDATE articles SET email = ?", value)`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_SelectAll_StringArg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `connection.select_all("SELECT email FROM articles")`)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_FindBySql_Heredoc_LineNumber(t *testing.T) {
+	// Verify the line number reported for a heredoc SQL argument.
+	// The heredoc_body node's StartPoint().Row determines what line we report.
+	src := "Article.find_by_sql(<<~SQL)\n  SELECT * FROM articles WHERE email = ?\nSQL\n"
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", src)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	t.Logf("heredoc ref: line=%d text=%q", refs[0].Line, refs[0].Text)
+}
+
+func TestScanRubyStringRefs_Heredoc_NoDMLPrefix_NotMatched(t *testing.T) {
+	src := "Article.find_by_sql(<<~MSG)\n  some random text with email in it\nMSG\n"
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", src)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected no refs for non-SQL heredoc, got %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Heredoc_Execute(t *testing.T) {
+	src := "connection.execute(<<~SQL)\n  UPDATE articles SET email = ?\nSQL\n"
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", src)
+	refs, _, err := ScanRubyStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -38,3 +38,7 @@ References found for Article.title
   references.rb:61          [string] Article.sum(:title)                                   # sum
   references.rb:64          [string] t = Article.arel_table[:title]                        # table subscript
   references.rb:65          [string] Article.arel_table[:title].eq(value)                  # arel condition
+  references.rb:81          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  references.rb:82          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  references.rb:83          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  references.rb:84          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -76,4 +76,12 @@ if false
   article.instance_variable_get(:@title)               # instance_variable_get (not detectable)
   article.title_changed?                                # attribute_changed? (name-mangled)
   Article.find_by_title(value)                          # dynamic finder (name-mangled)
+
+  # ── Raw SQL ───────────────────────────────────────────────────────────────────
+  Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc
+    SELECT title FROM articles WHERE title = ?
+  SQL
 end


### PR DESCRIPTION
## Summary

- Add `rubySqlMethods` map (`find_by_sql`, `execute`, `select_all`) in `rails.go`
- Detect field names in raw SQL string arguments to those methods, emitting `[sql ref]` prefixed references
- Detect field names in heredoc SQL arguments (`<<~SQL`, `<<-SQL`, `<<SQL`) via a new `"heredoc_body"` case in `walkNodeRubyStringRefs`
- Extend pattern battery (`test_patterns/rails/references.rb` + `golden_title.txt`) with raw SQL examples
- Add unit tests covering string-arg and heredoc variants, including a line-number assertion for heredoc calls

Closes #75

## Test plan

- [x] `go test ./internal/refs/` — 100% statement coverage maintained
- [x] `TestE2E_PatternBattery_Rails` — byte-for-exact-byte golden file comparison passes
- [x] All other e2e and unit tests pass
- [x] `golangci-lint` reports 0 issues