### PR TITLE
fix(rails): detect arel_table[:field] without explicit class receiver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,12 @@ jobs:
 
       - name: Run e2e tests
         run: make test-e2e
+
+      - name: Check golden files are up-to-date
+        run: |
+          make update-golden
+          if ! git diff --exit-code test_patterns/; then
+            echo ""
+            echo "Golden files are out of date. Run 'make update-golden' and commit the changes."
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ test-e2e: build-e2e ## Run end-to-end tests
 clean-e2e: ## Remove e2e test binary
 	rm -f e2e/$(BINARY_NAME)-e2e-test
 
+update-golden: build-e2e ## Regenerate golden files for pattern battery tests
+	@cd e2e && $(GOTEST) . -run TestE2E_PatternBattery -update -v
+
 check-coverage: ## Run tests with coverage and enforce minimum threshold
 	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
 	@coverage_file=$$(mktemp); \

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,10 +1,14 @@
 package e2e
 
 import (
+	"bufio"
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -252,15 +256,17 @@ func TestE2E_MissingFlags(t *testing.T) {
 
 func TestE2E_PatternBattery_Django(t *testing.T) {
 	runPatternBattery(t, "django", "../test_patterns/django/golden_title.txt",
+		[]string{"../test_patterns/django/references.py"},
 		"check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
 }
 
 func TestE2E_PatternBattery_Rails(t *testing.T) {
 	runPatternBattery(t, "rails", "../test_patterns/rails/golden_title.txt",
+		[]string{"../test_patterns/rails/references.rb"},
 		"check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
 }
 
-func runPatternBattery(t *testing.T, name, goldenPath string, args ...string) {
+func runPatternBattery(t *testing.T, name, goldenPath string, noRefFiles []string, args ...string) {
 	t.Helper()
 	out, err := run(t, args...)
 	if err != nil {
@@ -279,5 +285,31 @@ func runPatternBattery(t *testing.T, name, goldenPath string, args ...string) {
 	}
 	if !bytes.Equal(out, golden) {
 		t.Errorf("%s output differs from golden — run 'make update-golden' to refresh\ngot:\n%s\nwant:\n%s", name, out, golden)
+	}
+	assertNoRefs(t, out, noRefFiles)
+}
+
+// assertNoRefs scans srcFiles for lines marked [no-ref] and asserts none of
+// those line numbers appear in the colref output.
+func assertNoRefs(t *testing.T, out []byte, srcFiles []string) {
+	t.Helper()
+	for _, srcFile := range srcFiles {
+		f, err := os.Open(srcFile)
+		if err != nil {
+			t.Fatalf("assertNoRefs: cannot open %s: %v", srcFile, err)
+		}
+		base := filepath.Base(srcFile)
+		lineNum := 0
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			lineNum++
+			if strings.Contains(scanner.Text(), "[no-ref]") {
+				needle := fmt.Sprintf("%s:%d", base, lineNum)
+				if bytes.Contains(out, []byte(needle)) {
+					t.Errorf("[no-ref] line was detected but should not be: %s", needle)
+				}
+			}
+		}
+		f.Close()
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -2,10 +2,13 @@ package e2e
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"os/exec"
 	"testing"
 )
+
+var update = flag.Bool("update", false, "overwrite golden files with current output")
 
 const binaryName = "colref-e2e-test"
 
@@ -248,29 +251,33 @@ func TestE2E_MissingFlags(t *testing.T) {
 }
 
 func TestE2E_PatternBattery_Django(t *testing.T) {
-	out, err := run(t, "check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
-	if err != nil {
-		t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
-	}
-	golden, err := os.ReadFile("../test_patterns/django/golden_title.txt")
-	if err != nil {
-		t.Fatalf("failed to read golden file: %v", err)
-	}
-	if !bytes.Equal(out, golden) {
-		t.Errorf("output differs from golden\ngot:\n%s\nwant:\n%s", out, golden)
-	}
+	runPatternBattery(t, "django", "../test_patterns/django/golden_title.txt",
+		"check", "--orm", "django", "--model", "Article", "--field", "title", "../test_patterns/django")
 }
 
 func TestE2E_PatternBattery_Rails(t *testing.T) {
-	out, err := run(t, "check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
+	runPatternBattery(t, "rails", "../test_patterns/rails/golden_title.txt",
+		"check", "--orm", "rails", "--model", "Article", "--field", "title", "../test_patterns/rails")
+}
+
+func runPatternBattery(t *testing.T, name, goldenPath string, args ...string) {
+	t.Helper()
+	out, err := run(t, args...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
 	}
-	golden, err := os.ReadFile("../test_patterns/rails/golden_title.txt")
+	if *update {
+		if err := os.WriteFile(goldenPath, out, 0o644); err != nil {
+			t.Fatalf("failed to write golden file: %v", err)
+		}
+		t.Logf("updated golden file: %s", goldenPath)
+		return
+	}
+	golden, err := os.ReadFile(goldenPath)
 	if err != nil {
 		t.Fatalf("failed to read golden file: %v", err)
 	}
 	if !bytes.Equal(out, golden) {
-		t.Errorf("output differs from golden\ngot:\n%s\nwant:\n%s", out, golden)
+		t.Errorf("%s output differs from golden — run 'make update-golden' to refresh\ngot:\n%s\nwant:\n%s", name, out, golden)
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -310,6 +310,8 @@ func assertNoRefs(t *testing.T, out []byte, srcFiles []string) {
 				}
 			}
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			t.Fatalf("assertNoRefs: cannot close %s: %v", srcFile, err)
+		}
 	}
 }

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -229,12 +229,15 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 		}
 
 	case "element_reference":
-		// Article.arel_table[:field]
+		// Article.arel_table[:field] or arel_table[:field] (implicit self)
 		if node.ChildCount() >= 3 {
 			receiver := node.Child(0)
-			if receiver != nil && receiver.Type() == "call" {
-				m := receiver.ChildByFieldName("method")
-				if m != nil && m.Content(src) == "arel_table" {
+			if receiver != nil {
+				isArelTable := (receiver.Type() == "call" &&
+					receiver.ChildByFieldName("method") != nil &&
+					receiver.ChildByFieldName("method").Content(src) == "arel_table") ||
+					(receiver.Type() == "identifier" && receiver.Content(src) == "arel_table")
+				if isArelTable {
 					for i := 1; i < int(node.ChildCount()); i++ {
 						sym := node.Child(i)
 						if sym.Type() == "simple_symbol" && rubySymbolName(sym, src) == fieldName {

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2094,6 +2094,22 @@ func TestScanRubyStringRefs_ArelTable(t *testing.T) {
 	}
 }
 
+func TestScanRubyStringRefs_ArelTableImplicitSelf(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `scope :with_username, ->(v) { where(arel_table[:username].lower.in(v)) }`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "username")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0].Text != "[string] scope :with_username, ->(v) { where(arel_table[:username].lower.in(v)) }" {
+		t.Errorf("unexpected text: %q", refs[0].Text)
+	}
+}
+
 func TestScanRubyStringRefs_StringExactMatch(t *testing.T) {
 	// pluck("email") — exact string match → [string]
 	dir := t.TempDir()

--- a/test_patterns/django/references.py
+++ b/test_patterns/django/references.py
@@ -44,7 +44,7 @@ if False:
     x = getattr(article, 'title')                          # getattr literal
     x = getattr(article, 'title', '')                      # getattr with default
     x = operator.attrgetter('title')(article)              # attrgetter
-    x = getattr(article, field_name)                       # variable (not detectable)
+    x = getattr(article, field_name)                       # [no-ref] dynamic key in variable; field name not statically visible
 
     # ── ORM — lookup methods ──────────────────────────────────────────────────
     qs = Article.objects.filter(title='x')                 # filter keyword

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -38,7 +38,8 @@ References found for Article.title
   references.rb:61          [string] Article.sum(:title)                                   # sum
   references.rb:64          [string] t = Article.arel_table[:title]                        # table subscript
   references.rb:65          [string] Article.arel_table[:title].eq(value)                  # arel condition
-  references.rb:81          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
-  references.rb:82          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
-  references.rb:83          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
-  references.rb:84          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc
+  references.rb:66          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
+  references.rb:82          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  references.rb:83          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  references.rb:84          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  references.rb:85          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -74,9 +74,9 @@ if false
 
   # ── Dynamic / metaprogramming ─────────────────────────────────────────────────
   article.respond_to?(:title)                           # respond_to?
-  article.instance_variable_get(:@title)               # instance_variable_get (not detectable)
-  article.title_changed?                                # attribute_changed? (name-mangled)
-  Article.find_by_title(value)                          # dynamic finder (name-mangled)
+  article.instance_variable_get(:@title)               # [no-ref] @title is name-mangled; ivar name differs from field name
+  article.title_changed?                                # [no-ref] attribute_changed? suffix mangles the field name
+  Article.find_by_title(value)                          # [no-ref] dynamic finder encodes field name in method name
 
   # ── Raw SQL ───────────────────────────────────────────────────────────────────
   Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -63,6 +63,7 @@ if false
   # ── Arel ──────────────────────────────────────────────────────────────────────
   t = Article.arel_table[:title]                        # table subscript
   Article.arel_table[:title].eq(value)                  # arel condition
+  scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
 
   # ── Model declarations ────────────────────────────────────────────────────────
   # (see app/models/article.rb for validates and scope patterns)


### PR DESCRIPTION
## Summary

- Extend `element_reference` handling in `walkNodeRubyStringRefs` to accept `arel_table` as an `identifier` node (implicit `self`) in addition to the existing `call` node form
- Add test `TestScanRubyStringRefs_ArelTableImplicitSelf` covering the `scope :with_username, ->(v) { where(arel_table[:username].lower.in(v)) }` pattern

## Test plan

- [ ] `TestScanRubyStringRefs_ArelTable` (existing — explicit receiver) still passes
- [ ] `TestScanRubyStringRefs_ArelTableImplicitSelf` (new — implicit self) passes
- [ ] All tests pass (`go test ./...`)

Closes #134