### PR TITLE
feat: add install.sh for one-line installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,23 @@ The following directories are never scanned:
 
 ## Installation
 
-Binaries for Linux and macOS will be available on the [releases page](https://github.com/shinagawa-web/colref/releases) once the first version ships.
+### One-line installer (Linux and macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
+```
+
+Installs the latest release binary to `/usr/local/bin`. The script detects your OS and architecture automatically, downloads the matching tarball from the [releases page](https://github.com/shinagawa-web/colref/releases), and verifies the SHA-256 checksum before installing.
+
+To install to a different directory, set `INSTALL_DIR`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=~/.local/bin sh
+```
+
+### Manual download
+
+Pre-built binaries are also available directly on the [releases page](https://github.com/shinagawa-web/colref/releases).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Installs the latest release binary to `/usr/local/bin`. The script detects your 
 To install to a different directory, set `INSTALL_DIR`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=~/.local/bin sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=$HOME/.local/bin sh
 ```
 
 ### Manual download

--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,8 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   ACTUAL=$(shasum -a 256 "${TARBALL}" | awk '{print $1}')
 else
-  echo "warning: sha256sum and shasum not found; skipping checksum verification" >&2
-  ACTUAL="${EXPECTED}"
+  echo "error: sha256sum or shasum is required for checksum verification" >&2
+  exit 1
 fi
 if [ "${ACTUAL}" != "${EXPECTED}" ]; then
   echo "error: checksum mismatch for ${TARBALL}" >&2
@@ -59,11 +59,11 @@ fi
 
 tar -xzf "${TARBALL}"
 
-mkdir -p "${INSTALL_DIR}"
-if [ -w "${INSTALL_DIR}" ]; then
+if [ -d "${INSTALL_DIR}" ] && [ -w "${INSTALL_DIR}" ]; then
   mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
 else
   echo "Requesting elevated permissions to install to ${INSTALL_DIR}..."
+  sudo mkdir -p "${INSTALL_DIR}"
   sudo mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="shinagawa-web/colref"
+BINARY="colref"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+case "$(uname -s)" in
+  Linux*)  OS="linux" ;;
+  Darwin*) OS="darwin" ;;
+  *) echo "error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64)        ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "error: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep '"tag_name"' \
+  | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+if [ -z "${VERSION}" ]; then
+  echo "error: could not determine latest release version" >&2
+  exit 1
+fi
+
+VERSION_NUMBER="${VERSION#v}"
+TARBALL="${BINARY}_${VERSION_NUMBER}_${OS}_${ARCH}.tar.gz"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+echo "Installing ${BINARY} ${VERSION} (${OS}/${ARCH}) to ${INSTALL_DIR}..."
+
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+curl -fsSL "${BASE_URL}/${TARBALL}" -o "${TMP}/${TARBALL}"
+curl -fsSL "${BASE_URL}/checksums.txt" -o "${TMP}/checksums.txt"
+
+cd "${TMP}"
+EXPECTED=$(grep "${TARBALL}" checksums.txt | awk '{print $1}')
+if [ -z "${EXPECTED}" ]; then
+  echo "error: ${TARBALL} not found in checksums.txt" >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL=$(sha256sum "${TARBALL}" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL=$(shasum -a 256 "${TARBALL}" | awk '{print $1}')
+else
+  echo "warning: sha256sum and shasum not found; skipping checksum verification" >&2
+  ACTUAL="${EXPECTED}"
+fi
+if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+  echo "error: checksum mismatch for ${TARBALL}" >&2
+  exit 1
+fi
+
+tar -xzf "${TARBALL}"
+
+mkdir -p "${INSTALL_DIR}"
+if [ -w "${INSTALL_DIR}" ]; then
+  mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+  echo "Requesting elevated permissions to install to ${INSTALL_DIR}..."
+  sudo mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+
+echo "${BINARY} ${VERSION} installed to ${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
Closes #88

## Summary

- Add `install.sh` that detects OS/arch, fetches the latest release via GitHub API, downloads and verifies the SHA-256 checksum, and installs the binary
- Checksum is extracted from `checksums.txt` and compared directly (handles the `artifacts/` path prefix in the checksum file)
- Falls back to `sudo` if `INSTALL_DIR` is not writable; `INSTALL_DIR` defaults to `/usr/local/bin` and is created with `mkdir -p` if absent
- Update `README.md` Installation section with the one-liner and `INSTALL_DIR` override example

## Test plan

- [x] Smoke-tested end-to-end against the live v0.5.0 release: `INSTALL_DIR=$(mktemp -d) sh install.sh` — binary downloaded, checksum verified, binary executable