### PR TITLE
docs: build documentation site with Hugo and publish to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: docs/go.mod
+          cache-dependency-path: docs/go.sum
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.158.0"
+          extended: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build
+        working-directory: docs
+        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ colref uses static AST analysis and cannot detect every reference pattern. Refer
 
 **Rails:** attribute access, most ActiveRecord query/creation/update methods (`where`, `order`, `pluck`, `create`, `update`, `find_by`, etc.), Arel subscripts, and SQL string fragments are detected. Not detected: `read_attribute`, `send`, symbol subscript (`record[:field]`), `validates` declarations, and strong parameters.
 
-For the full per-pattern breakdown, see [docs/content/detection-patterns.md](docs/content/detection-patterns.md).
+For the full per-pattern breakdown, see [docs/content/docs/detection-patterns.md](docs/content/docs/detection-patterns.md).
 
 If colref reports no references, treat it as "none found by the scanner" — not as a guarantee the column is unused.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ colref uses static AST analysis and cannot detect every reference pattern. Refer
 
 **Rails:** attribute access, most ActiveRecord query/creation/update methods (`where`, `order`, `pluck`, `create`, `update`, `find_by`, etc.), Arel subscripts, and SQL string fragments are detected. Not detected: `read_attribute`, `send`, symbol subscript (`record[:field]`), `validates` declarations, and strong parameters.
 
-For the full per-pattern breakdown, see [docs/detection-patterns.md](docs/detection-patterns.md).
+For the full per-pattern breakdown, see [docs/content/detection-patterns.md](docs/content/detection-patterns.md).
 
 If colref reports no references, treat it as "none found by the scanner" — not as a guarantee the column is unused.
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+public/
+resources/
+.hugo_build.lock

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1,0 +1,33 @@
+---
+title: colref
+type: docs
+---
+
+# colref
+
+Check whether a database column is still referenced in your codebase before you delete it.
+
+## Why
+
+You want to remove a column from a long-running system. The column looks unused, but you're not sure. A full-text search returns hits inside comments, test fixtures, and migration history — noise that makes it hard to tell whether the column is actually read or written in live code.
+
+colref scans your codebase with an AST parser, skips comments and string literals, and tells you where the column is referenced. If it finds nothing, you have a concrete starting point for the deletion decision. The final call is yours.
+
+## Quick start
+
+```
+colref check --orm django --model User --field email
+```
+
+```
+Scanning 142 files...
+
+No references found for User.email
+
+  Verify manually before deleting.
+```
+
+→ [Getting started]({{< relref "getting-started" >}}) — installation and first run  
+→ [Usage]({{< relref "usage/_index" >}}) — flags reference and ORM-specific behavior  
+→ [How it works]({{< relref "how-it-works" >}}) — AST parsing and schema extraction  
+→ [Detection patterns]({{< relref "detection-patterns" >}}) — what is and isn't detected  

--- a/docs/content/docs/contributing.md
+++ b/docs/content/docs/contributing.md
@@ -1,0 +1,62 @@
+---
+title: Contributing
+weight: 60
+---
+
+# Contributing
+
+## Development setup
+
+**Prerequisites:** Go 1.21+
+
+```sh
+git clone https://github.com/shinagawa-web/colref.git
+cd colref
+make install-hooks
+```
+
+## Running tests
+
+```sh
+make test           # unit tests (race detector enabled)
+make test-e2e       # end-to-end tests
+make check-coverage # unit tests + enforce 100% coverage
+```
+
+## Linting
+
+```sh
+make static-lint    # run golangci-lint
+make lint-fix       # run golangci-lint --fix
+```
+
+## Building
+
+```sh
+make build          # build ./colref binary
+make install        # install to $GOPATH/bin
+```
+
+## Golden file tests
+
+The pattern battery tests in `e2e/` compare output against golden files in `test_patterns/`. If you add or change a detection pattern, regenerate the golden files:
+
+```sh
+make update-golden
+```
+
+Golden files must be committed and stay in sync with the implementation. CI enforces this.
+
+## Adding a new detection pattern
+
+1. Add the pattern to the relevant scanner in `internal/`
+2. Add test cases to the pattern battery in `test_patterns/`
+3. Run `make update-golden` to regenerate golden files
+4. Run `make test && make test-e2e` to verify everything passes
+5. Update [Detection patterns]({{< relref "detection-patterns" >}}) with the new pattern
+
+## Submitting changes
+
+- Open an issue before starting non-trivial work
+- Keep PRs focused — one logical change per PR
+- All tests must pass; coverage must stay at 100%

--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -1,17 +1,15 @@
+---
+title: Detection patterns
+weight: 40
+---
+
 # Detection patterns
 
 colref uses static AST analysis. It can only detect patterns where the field name appears as a literal in the source. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design — static analysis cannot determine what string `field_name` holds.
 
-This page documents exactly which patterns are and are not detected for each ORM.
+This page documents exactly which patterns are and are not detected for each ORM. The ground truth is the golden test files in `test_patterns/`.
 
-> **Note:** This page may lag behind the code. The golden files are enforced by CI and are always up to date — when in doubt, check those first.
->
-> - [`test_patterns/django/golden_title.txt`](../test_patterns/django/golden_title.txt) — currently detected Django patterns
-> - [`test_patterns/rails/golden_title.txt`](../test_patterns/rails/golden_title.txt) — currently detected Rails patterns
-> - [`test_patterns/django/references.py`](../test_patterns/django/references.py) — full Django pattern set under test (detected + not detected)
-> - [`test_patterns/rails/references.rb`](../test_patterns/rails/references.rb) — full Rails pattern set under test (detected + not detected)
-
-### Output labels
+## Output labels
 
 All three mean the reference was detected. The label indicates how it was found and how confident the match is.
 
@@ -21,7 +19,7 @@ All three mean the reference was detected. The label indicates how it was found 
 | ✅ `[string]` | Literal string or symbol passed to a known ORM method (`.where(title: value)`, `.pluck(:title)`) | High — method is known to accept field names |
 | ✅ `[sql ref]` | Word-boundary substring match inside a raw SQL string (`.where("title = ?", value)`) | Lower — verify manually, false positives possible |
 
-## Django
+## Django {#django}
 
 ### Detected
 
@@ -176,7 +174,7 @@ The field name appears as the first positional string argument.
 
 ---
 
-## Rails
+## Rails {#rails}
 
 ### Detected
 

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -1,0 +1,76 @@
+---
+title: Getting started
+weight: 10
+---
+
+# Getting started
+
+## Installation
+
+Binaries for Linux and macOS are available on the [releases page](https://github.com/shinagawa-web/colref/releases).
+
+Download the archive for your platform, extract it, and place the `colref` binary somewhere on your `PATH`.
+
+**macOS / Linux (example)**
+
+```sh
+curl -L https://github.com/shinagawa-web/colref/releases/latest/download/colref_linux_amd64.tar.gz | tar xz
+mv colref /usr/local/bin/
+```
+
+Verify the install:
+
+```sh
+colref --version
+```
+
+## First run
+
+### Django project
+
+From your project root, run:
+
+```sh
+colref check --orm django --model Article --field title
+```
+
+colref finds all `models.py` files automatically, validates that `Article` has a `title` field, then walks your codebase reporting every live reference.
+
+**No references found:**
+
+```
+Scanning 87 files...
+
+No references found for Article.title
+
+  Verify manually before deleting.
+```
+
+**References found:**
+
+```
+Scanning 87 files...
+
+References found for Article.title
+
+  blog/views.py:14     article.title
+  blog/views.py:55     article.title
+  blog/serializers.py:9  ✅ [string] .values("title")
+  blog/admin.py:22     ❌ list_display = ["title"]   (not detected)
+```
+
+### Rails project
+
+From your project root, run:
+
+```sh
+colref check --orm rails --model Article --field title
+```
+
+colref reads `db/schema.rb` (or falls back to replaying `db/migrate/`) to validate the field exists, then scans `.rb` and `.erb` files for references.
+
+## Next steps
+
+- [Usage]({{< relref "usage/_index" >}}) — all flags, ORM-specific behavior
+- [Detection patterns]({{< relref "detection-patterns" >}}) — full breakdown of what is and isn't matched
+- [Limitations]({{< relref "limitations" >}}) — what static analysis can't cover

--- a/docs/content/docs/how-it-works.md
+++ b/docs/content/docs/how-it-works.md
@@ -1,0 +1,40 @@
+---
+title: How it works
+weight: 30
+---
+
+# How it works
+
+## Overview
+
+1. Reads your ORM schema source to extract the field list
+2. Walks the codebase and parses each file into an AST
+3. Reports every location where the field name appears as an attribute access (e.g. `user.email`)
+
+AST parsing avoids false positives from comments, migration files, and unrelated string matches that plain grep would surface.
+
+## Schema extraction
+
+**Django** — colref walks the target directory to find `models.py` files. Each file is parsed and the field list for the requested model is extracted. If the same model name appears in multiple files, colref exits with an error.
+
+**Rails** — colref reads `db/schema.rb` and maps table names to model names by convention (`users` → `User`). If `db/schema.rb` is absent, colref falls back to replaying `db/migrate/` in timestamp order, applying `create_table`, `add_column`, `remove_column`, `rename_column`, and `drop_table` operations to reconstruct the live schema.
+
+## AST scanning
+
+After schema extraction, colref walks the project tree. For each source file, it:
+
+1. Parses the file into an AST
+2. Visits every node looking for:
+   - **Attribute access** — `object.field` nodes (highest confidence)
+   - **ORM keyword arguments** — `.filter(field="x")`, `.where(field: value)`, etc. (`[string]` label)
+   - **Raw SQL strings** — word-boundary substring match inside SQL literals (`[sql ref]` label)
+
+Directories listed in the skip list (`.git`, `__pycache__`, `migrations`, `node_modules`, etc.) are never entered.
+
+## Output labels
+
+| Label | How found | Confidence |
+|-------|-----------|------------|
+| (none) | AST attribute node (`article.title`) | Highest — unambiguous |
+| `[string]` | Literal string or symbol passed to a known ORM method | High — method is known to accept field names |
+| `[sql ref]` | Word-boundary match inside a raw SQL string | Lower — verify manually, false positives possible |

--- a/docs/content/docs/limitations.md
+++ b/docs/content/docs/limitations.md
@@ -1,0 +1,26 @@
+---
+title: Limitations
+weight: 50
+---
+
+# Limitations
+
+colref uses static AST analysis and cannot detect every reference pattern. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design.
+
+**If colref reports no references, treat it as "none found by the scanner" — not as a guarantee the column is unused.**
+
+## Django
+
+Detected: attribute access, most ORM methods (`filter`, `exclude`, `get`, `Q`, `values`, `only`, `defer`, `order_by`, `F`, aggregates, etc.), and raw SQL strings.
+
+Not detected: `getattr` / `attrgetter`, `update_or_create`, `save(update_fields=[...])`, `_meta.get_field`, Django admin class attributes, DRF serializer fields, and form fields.
+
+## Rails
+
+Detected: attribute access, most ActiveRecord query/creation/update methods (`where`, `order`, `pluck`, `create`, `update`, `find_by`, etc.), Arel subscripts, and SQL string fragments.
+
+Not detected: `read_attribute`, `send`, symbol subscript (`record[:field]`), `validates` declarations, and strong parameters.
+
+## Full pattern breakdown
+
+See [Detection patterns]({{< relref "detection-patterns" >}}) for the complete per-pattern table with examples and result labels.

--- a/docs/content/docs/usage/_index.md
+++ b/docs/content/docs/usage/_index.md
@@ -1,0 +1,28 @@
+---
+title: Usage
+weight: 20
+bookFlatSection: true
+---
+
+# Usage
+
+## Command
+
+```
+colref check --orm <orm> --model <Model> --field <field> [path]
+```
+
+`path` is the project root to scan (default: current directory).
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `--orm` | ORM type: `django`, `rails` (required) |
+| `--model` | Model name to look up (required) |
+| `--field` | Field name to search for (required) |
+
+## ORM-specific behavior
+
+- [Django]({{< relref "django" >}}) — models.py detection, skipped directories
+- [Rails]({{< relref "rails" >}}) — schema.rb, migration fallback, scanned file types

--- a/docs/content/docs/usage/django.md
+++ b/docs/content/docs/usage/django.md
@@ -1,0 +1,61 @@
+---
+title: Django
+weight: 21
+---
+
+# Django
+
+## Example
+
+```sh
+colref check --orm django --model User --field email
+```
+
+Output when no references exist:
+
+```
+Scanning 142 files...
+
+No references found for User.email
+
+  Verify manually before deleting.
+```
+
+Output when references exist:
+
+```
+Scanning 142 files...
+
+References found for User.email
+
+  accounts/serializers.py:34   user.email
+  accounts/views.py:88         obj.email
+  notifications/tasks.py:12    instance.email
+```
+
+## models.py detection
+
+colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
+
+If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
+
+```
+model "User" found in multiple files:
+  accounts/models.py
+  legacy/models.py
+Use --model to disambiguate.
+```
+
+## Skipped directories
+
+The following directories are never scanned:
+
+- `.git`, and any directory whose name starts with `.`
+- `__pycache__`
+- `venv`, `.venv`
+- `migrations`
+- `node_modules`
+
+## Detection coverage
+
+See [Detection patterns — Django]({{< relref "detection-patterns#django" >}}) for the full per-pattern breakdown.

--- a/docs/content/docs/usage/rails.md
+++ b/docs/content/docs/usage/rails.md
@@ -1,0 +1,24 @@
+---
+title: Rails
+weight: 22
+---
+
+# Rails
+
+## Example
+
+```sh
+colref check --orm rails --model User --field email
+```
+
+colref reads `db/schema.rb` from the project root, infers model names from table names (`users` → `User`), and scans `.rb` and `.erb` files for attribute-access references.
+
+## Schema source
+
+colref first looks for `db/schema.rb`. If present, it extracts the current column list from there.
+
+If `db/schema.rb` is not present (some projects treat it as a generated artifact and do not commit it), colref falls back to `db/migrate/`. It replays migration files in timestamp order — `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table` — to reconstruct the current schema. Model and field validation remain fully intact.
+
+## Detection coverage
+
+See [Detection patterns — Rails]({{< relref "detection-patterns#rails" >}}) for the full per-pattern breakdown.

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,5 @@
+module github.com/shinagawa-web/colref/docs
+
+go 1.25
+
+require github.com/alex-shpak/hugo-book v0.14.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,0 +1,2 @@
+github.com/alex-shpak/hugo-book v0.14.0 h1:edQbxbKHZQoaHidnGR9dZ9EnoEqIV+kPjyEuAaDWvzc=
+github.com/alex-shpak/hugo-book v0.14.0/go.mod h1:3N2fYXAJzb31L13moUOXmPo2DC58VvQYJkGr9VniXfQ=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,0 +1,18 @@
+baseURL = "https://shinagawa-web.github.io/colref/"
+languageCode = "en-us"
+title = "colref"
+
+[module]
+  [[module.imports]]
+    path = "github.com/alex-shpak/hugo-book"
+
+[params]
+  BookTheme = "auto"
+  BookSearch = true
+  BookRepo = "https://github.com/shinagawa-web/colref"
+  BookToC = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
## Summary

- Add Hugo site source under `docs/` using the hugo-book theme (v0.14.0, via Hugo modules)
- Move `docs/detection-patterns.md` into `docs/content/docs/` and add Hugo front matter; update README link accordingly
- Add content pages: Getting Started, Usage (Django/Rails), How it Works, Limitations, Contributing
- Add `.github/workflows/docs.yml` to build and deploy to GitHub Pages on push to `main` (artifact-based deployment, no gh-pages branch)

## Test plan

- [x] `hugo --minify` builds cleanly locally (19 pages, 0 errors)
- [x] All internal `relref` links resolve without error
- [x] `docs/public/` and `docs/resources/` excluded via `docs/.gitignore` (not committed)
- [x] After merge, enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**
  - First deploy will fail until this is done

## Notes

- Hugo version pinned to `0.158.0` in the workflow (minimum required by hugo-book v0.14.0)
- Go setup step added so Hugo module downloads work on the CI runner
- `workflow_dispatch` trigger allows manual deploy without a push

Closes #82