### PR TITLE
fix: add root _index.md to fix blank homepage on GitHub Pages

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,34 @@
+---
+title: colref
+type: docs
+bookToc: false
+---
+
+# colref
+
+Check whether a database column is still referenced in your codebase before you delete it.
+
+## Why
+
+You want to remove a column from a long-running system. The column looks unused, but you're not sure. A full-text search returns hits inside comments, test fixtures, and migration history — noise that makes it hard to tell whether the column is actually read or written in live code.
+
+colref scans your codebase with an AST parser, skips comments and string literals, and tells you where the column is referenced. If it finds nothing, you have a concrete starting point for the deletion decision. The final call is yours.
+
+## Quick start
+
+```
+colref check --orm django --model User --field email
+```
+
+```
+Scanning 142 files...
+
+No references found for User.email
+
+  Verify manually before deleting.
+```
+
+→ [Getting started]({{< relref "/docs/getting-started" >}}) — installation and first run  
+→ [Usage]({{< relref "/docs/usage/_index" >}}) — flags reference and ORM-specific behavior  
+→ [How it works]({{< relref "/docs/how-it-works" >}}) — AST parsing and schema extraction  
+→ [Detection patterns]({{< relref "/docs/detection-patterns" >}}) — what is and isn't detected  

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -28,7 +28,7 @@ No references found for User.email
   Verify manually before deleting.
 ```
 
-→ [Getting started]({{< relref "/docs/getting-started" >}}) — installation and first run  
-→ [Usage]({{< relref "/docs/usage/_index" >}}) — flags reference and ORM-specific behavior  
-→ [How it works]({{< relref "/docs/how-it-works" >}}) — AST parsing and schema extraction  
-→ [Detection patterns]({{< relref "/docs/detection-patterns" >}}) — what is and isn't detected  
+→ [Getting started]({{< relref "docs/getting-started" >}}) — installation and first run  
+→ [Usage]({{< relref "docs/usage/_index" >}}) — flags reference and ORM-specific behavior  
+→ [How it works]({{< relref "docs/how-it-works" >}}) — AST parsing and schema extraction  
+→ [Detection patterns]({{< relref "docs/detection-patterns" >}}) — what is and isn't detected  

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1,33 +1,13 @@
 ---
-title: colref
+title: Documentation
 type: docs
 ---
 
-# colref
+# Documentation
 
-Check whether a database column is still referenced in your codebase before you delete it.
-
-## Why
-
-You want to remove a column from a long-running system. The column looks unused, but you're not sure. A full-text search returns hits inside comments, test fixtures, and migration history — noise that makes it hard to tell whether the column is actually read or written in live code.
-
-colref scans your codebase with an AST parser, skips comments and string literals, and tells you where the column is referenced. If it finds nothing, you have a concrete starting point for the deletion decision. The final call is yours.
-
-## Quick start
-
-```
-colref check --orm django --model User --field email
-```
-
-```
-Scanning 142 files...
-
-No references found for User.email
-
-  Verify manually before deleting.
-```
-
-→ [Getting started]({{< relref "getting-started" >}}) — installation and first run  
-→ [Usage]({{< relref "usage/_index" >}}) — flags reference and ORM-specific behavior  
-→ [How it works]({{< relref "how-it-works" >}}) — AST parsing and schema extraction  
-→ [Detection patterns]({{< relref "detection-patterns" >}}) — what is and isn't detected  
+- [Getting started]({{< relref "getting-started" >}}) — installation and first run
+- [Usage]({{< relref "usage/_index" >}}) — flags reference and ORM-specific behavior
+- [How it works]({{< relref "how-it-works" >}}) — AST parsing and schema extraction
+- [Detection patterns]({{< relref "detection-patterns" >}}) — what is and isn't detected
+- [Limitations]({{< relref "limitations" >}}) — what static analysis can't cover
+- [Contributing]({{< relref "contributing" >}}) — development setup and guidelines


### PR DESCRIPTION
## Summary

- Add `docs/content/_index.md` which was missing after restructuring content under `docs/content/docs/`
- Without this file, Hugo renders an empty article at `/`, causing a blank white page on the deployed site

## Root cause

When the content was moved from `docs/content/` to `docs/content/docs/`, the root `_index.md` was moved along with it. Hugo requires `content/_index.md` to render the homepage — the section-level `content/docs/_index.md` only renders the `/docs/` URL.

## Test plan

- [x] `hugo --minify` builds cleanly (no errors)
- [ ] After merge, verify https://shinagawa-web.github.io/colref/ shows homepage content

Closes #146