### PR TITLE
docs: restructure contributing page to lead with pre-push hook

### DIFF
--- a/docs/content/docs/contributing.md
+++ b/docs/content/docs/contributing.md
@@ -5,7 +5,7 @@ weight: 60
 
 # Contributing
 
-## Development setup
+## Setup
 
 **Prerequisites:** Go 1.21+
 
@@ -15,48 +15,37 @@ cd colref
 make install-hooks
 ```
 
-## Running tests
+`make install-hooks` installs a pre-push hook. Every time you run `git push`, it automatically runs:
 
-```sh
-make test           # unit tests (race detector enabled)
-make test-e2e       # end-to-end tests
-make check-coverage # unit tests + enforce 100% coverage
-```
+1. **Lint** — golangci-lint
+2. **Tests + coverage** — full test suite with 100% coverage enforcement
+3. **Benchmarks** — runs benchmarks; compares against `main` if `benchstat` is installed
 
-## Linting
-
-```sh
-make static-lint    # run golangci-lint
-make lint-fix       # run golangci-lint --fix
-```
-
-## Building
-
-```sh
-make build          # build ./colref binary
-make install        # install to $GOPATH/bin
-```
-
-## Golden file tests
-
-The pattern battery tests in `e2e/` compare output against golden files in `test_patterns/`. If you add or change a detection pattern, regenerate the golden files:
-
-```sh
-make update-golden
-```
-
-Golden files must be committed and stay in sync with the implementation. CI enforces this.
+That's it. Write code, push, the hook tells you if anything is broken.
 
 ## Adding a new detection pattern
 
 1. Add the pattern to the relevant scanner in `internal/`
 2. Add test cases to the pattern battery in `test_patterns/`
 3. Run `make update-golden` to regenerate golden files
-4. Run `make test && make test-e2e` to verify everything passes
-5. Update [Detection patterns]({{< relref "detection-patterns" >}}) with the new pattern
+4. Update [Detection patterns]({{< relref "detection-patterns" >}}) with the new pattern
+5. Push — the hook verifies everything passes
 
 ## Submitting changes
 
 - Open an issue before starting non-trivial work
 - Keep PRs focused — one logical change per PR
 - All tests must pass; coverage must stay at 100%
+
+## Running checks manually
+
+If you need to run individual checks without pushing:
+
+```sh
+make static-lint      # lint only
+make test             # unit tests
+make test-e2e         # end-to-end tests
+make check-coverage   # tests + 100% coverage enforcement
+make bench            # benchmarks
+make update-golden    # regenerate golden files
+```

--- a/docs/content/docs/contributing.md
+++ b/docs/content/docs/contributing.md
@@ -18,18 +18,19 @@ make install-hooks
 `make install-hooks` installs a pre-push hook. Every time you run `git push`, it automatically runs:
 
 1. **Lint** — golangci-lint
-2. **Tests + coverage** — full test suite with 100% coverage enforcement
+2. **Unit tests + coverage** — unit tests with 100% coverage enforcement (e2e excluded)
 3. **Benchmarks** — runs benchmarks; compares against `main` if `benchstat` is installed
 
-That's it. Write code, push, the hook tells you if anything is broken.
+That's it for most changes. Write code, push, the hook tells you if anything is broken.
 
 ## Adding a new detection pattern
 
 1. Add the pattern to the relevant scanner in `internal/`
 2. Add test cases to the pattern battery in `test_patterns/`
 3. Run `make update-golden` to regenerate golden files
-4. Update [Detection patterns]({{< relref "detection-patterns" >}}) with the new pattern
-5. Push — the hook verifies everything passes
+4. Run `make test-e2e` to verify the pattern battery passes (the pre-push hook does not run e2e)
+5. Update [Detection patterns]({{< relref "detection-patterns" >}}) with the new pattern
+6. Push — the hook runs lint, unit tests, and benchmarks
 
 ## Submitting changes
 


### PR DESCRIPTION
## Summary

The contributing page was listing many individual make commands without explaining that the pre-push hook runs all of them automatically. This creates unnecessary friction for contributors.

**Before:** wall of commands — Running tests, Linting, Building, Golden file tests, ...

**After:** install the hook once, push, done. Individual commands moved to a secondary section.

Closes #149