### PR TITLE
feat: add --version / -v flag

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -52,7 +52,7 @@ jobs:
           CC: ${{ matrix.cc }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          go build -o colref ./cmd/colref/
+          go build -ldflags "-X main.version=${GITHUB_REF_NAME}" -o colref ./cmd/colref/
           tar czf "colref_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz" \
             colref LICENSE README.md
 

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -5,9 +5,13 @@ import (
 	"os"
 )
 
-var exit = os.Exit
+var (
+	exit    = os.Exit
+	version = "dev"
+)
 
 func main() {
+	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)

--- a/cmd/colref/main.go
+++ b/cmd/colref/main.go
@@ -11,7 +11,6 @@ var (
 )
 
 func main() {
-	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)

--- a/cmd/colref/root.go
+++ b/cmd/colref/root.go
@@ -7,4 +7,9 @@ var rootCmd = &cobra.Command{
 	Short:         "Check whether a DB column is still referenced before you delete it",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	Version:       version,
+}
+
+func init() {
+	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 }

--- a/cmd/colref/root_test.go
+++ b/cmd/colref/root_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestRootCmd_Help(t *testing.T) {
@@ -11,5 +14,26 @@ func TestRootCmd_Help(t *testing.T) {
 	rootCmd.SetArgs([]string{"--help"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRootCmd_Version(t *testing.T) {
+	// Reset flag state left by any previous Execute call so cobra does not
+	// short-circuit to Help before reaching the version flag check.
+	rootCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+
+	rootCmd.Version = "v1.2.3"
+	buf := new(strings.Builder)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{"--version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "v1.2.3") {
+		t.Errorf("version output %q does not contain v1.2.3", buf.String())
 	}
 }

--- a/cmd/colref/root_test.go
+++ b/cmd/colref/root_test.go
@@ -21,8 +21,18 @@ func TestRootCmd_Version(t *testing.T) {
 	// Reset flag state left by any previous Execute call so cobra does not
 	// short-circuit to Help before reaching the version flag check.
 	rootCmd.Flags().VisitAll(func(f *pflag.Flag) {
-		_ = f.Value.Set(f.DefValue)
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("reset flag %q: %v", f.Name, err)
+		}
 		f.Changed = false
+	})
+
+	prevVersion := rootCmd.Version
+	t.Cleanup(func() {
+		rootCmd.Version = prevVersion
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
 	})
 
 	rootCmd.Version = "v1.2.3"
@@ -33,7 +43,7 @@ func TestRootCmd_Version(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "v1.2.3") {
-		t.Errorf("version output %q does not contain v1.2.3", buf.String())
+	if got := buf.String(); got != "colref v1.2.3\n" {
+		t.Errorf("version output = %q, want %q", got, "colref v1.2.3\n")
 	}
 }


### PR DESCRIPTION
Closes #151

## Summary

- Add a package-level `version` variable (default `"dev"`) and assign it to `rootCmd.Version` in `main()` — cobra automatically handles `--version` and `-v` from that
- Inject the version string at build time in the release workflow: `-ldflags "-X main.version=${GITHUB_REF_NAME}"`
- Add `TestRootCmd_Version`; cobra reuses the package-level `rootCmd` across tests so help-flag state from a prior `Execute` call must be reset (both value and Changed) before running

## Test plan

- [x] `go test ./cmd/colref/ -v -run TestRootCmd` — Help and Version tests both pass together
- [x] Coverage stays at 100%