### PR TITLE
feat: add release.yml to categorize GitHub release notes by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Internal
+      labels:
+        - ci
+        - chore
+        - refactor
+        - test
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

- Adds `.github/release.yml` to enable GitHub-native categorized release notes
- Categories match the labels applied by `auto-label.yml`: Breaking Changes, New Features, Bug Fixes, Documentation, Dependencies, Internal (ci/chore/refactor/test), Other Changes
- No changes to the existing build/release workflow — `gh release create --generate-notes` picks this up automatically

## Approach

Issue #153 originally described a GoReleaser `changelog.groups` implementation. After investigation, `go-tree-sitter` requires `CGO_ENABLED=1`, which prevents using a single GoReleaser runner across platforms. Rather than add cross-compilation complexity to GoReleaser, we deliberately chose the GitHub-native `.github/release.yml` approach — it achieves the same categorized release notes with no workflow changes.

Closes #153