### PR TITLE
ci: complete Codecov integration with token, SHA pin, and badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           echo "Coverage OK."
 
       - name: Upload coverage to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: coverage.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,11 @@ jobs:
           echo "Coverage OK."
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   e2e:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # colref
 
+[![codecov](https://codecov.io/gh/shinagawa-web/colref/graph/badge.svg)](https://codecov.io/gh/shinagawa-web/colref)
+
 Check whether a database column is still referenced in your codebase before you delete it.
 
 ## Why


### PR DESCRIPTION
## Summary

- Pin `codecov/codecov-action` to SHA digest (`e79a6962` = v6)
- Add `token: ${{ secrets.CODECOV_TOKEN }}` (token already configured in repo secrets)
- Add `fail_ci_if_error: true` to catch upload failures
- Add Codecov coverage badge to README

Closes #84

## Test plan

- [x] CI passes on this PR
- [x] Codecov comment appears on the PR
- [x] Badge renders correctly in README preview