### PR TITLE
feat: distribute via Homebrew tap using goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,9 +19,8 @@ jobs:
           - os: ubuntu-latest
             goos: linux
             goarch: arm64
-            cc: aarch64-linux-gnu-gcc
             apt: gcc-aarch64-linux-gnu
-          - os: macos-latest
+          - os: macos-13
             goos: darwin
             goarch: amd64
           - os: macos-latest
@@ -44,22 +43,21 @@ jobs:
         if: matrix.apt != ''
         run: sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Build and archive
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: build --single-target --skip=validate
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "1"
-          CC: ${{ matrix.cc }}
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          go build -ldflags "-X main.version=${GITHUB_REF_NAME}" -o colref ./cmd/colref/
-          tar czf "colref_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz" \
-            colref LICENSE README.md
+
+      - name: Rename artifacts.json for merge
+        run: mv dist/artifacts.json dist/artifacts-${{ matrix.goos }}-${{ matrix.goarch }}.json
 
       - uses: actions/upload-artifact@v7
         with:
-          name: colref-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: "*.tar.gz"
+          name: dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
 
   release:
     needs: build
@@ -67,21 +65,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v8
         with:
-          path: artifacts/
+          path: dist/
           merge-multiple: true
 
-      - name: Create checksums
-        run: sha256sum artifacts/*.tar.gz > artifacts/checksums.txt
+      - name: Merge artifacts.json
+        run: jq -s 'flatten' dist/artifacts-*.json > dist/artifacts.json
 
-      - name: Create GitHub Release
-        run: |
-          gh release create "$GITHUB_REF_NAME" \
-            artifacts/*.tar.gz \
-            artifacts/checksums.txt \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --skip=build
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+version: 2
+
+builds:
+  - id: colref
+    main: ./cmd/colref/
+    binary: colref
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+    ldflags:
+      - -s -w
+      - -X main.version={{.Tag}}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: "colref_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  use: github-native
+
+release:
+  draft: false
+  prerelease: auto
+
+brews:
+  - name: colref
+    repository:
+      owner: shinagawa-web
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/shinagawa-web/colref
+    description: Check whether a database column is still referenced in your codebase before you delete it.
+    license: MIT
+    install: |
+      bin.install "colref"
+    test: |
+      system "#{bin}/colref", "--version"


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yml` (v2) with builds for all four targets (linux/darwin × amd64/arm64), `checksums.txt` generation, and a `brews` section that pushes a formula to `shinagawa-web/homebrew-tap`
- Migrate `.github/workflows/goreleaser.yml` from the manual `go build` matrix to `goreleaser/goreleaser-action@v6` using the split-build pattern required for CGO projects
- `darwin/amd64` uses `macos-13` (Intel) for native CGO; `darwin/arm64` uses `macos-latest` (Apple Silicon)
- `linux/arm64` cross-compilation is handled via `.goreleaser.yml` `overrides` (`CC=aarch64-linux-gnu-gcc`); the cross-compiler is installed in the workflow
- Archive naming (`colref_VERSION_OS_ARCH.tar.gz`) and `checksums.txt` format remain compatible with `install.sh`
- `changelog.use: github-native` delegates release notes to GitHub, which respects the existing `.github/release.yml` categories

## Manual setup required

Before the first tagged release, add `HOMEBREW_TAP_GITHUB_TOKEN` to repository secrets:

1. Create a fine-grained PAT (or classic PAT with `repo` scope) that has **Contents: Read and write** on `shinagawa-web/homebrew-tap`
2. Add it as a secret named `HOMEBREW_TAP_GITHUB_TOKEN` in this repository's settings

## Test plan

- [ ] Verify all four build matrix jobs complete and upload `dist/` artifacts
- [ ] Verify the release job merges `artifacts.json` correctly and creates the GitHub release
- [ ] After first tagged release, run `brew install shinagawa-web/tap/colref` to confirm end-to-end (tracked as task 5 in #92)

Closes #92