### PR TITLE
ci: add go-install-check workflow

### DIFF
--- a/.github/workflows/go-install-check.yml
+++ b/.github/workflows/go-install-check.yml
@@ -1,0 +1,31 @@
+name: go-install-check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
+
+jobs:
+  go-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install via go install
+        run: go install github.com/shinagawa-web/colref/cmd/colref@latest
+
+      - name: Verify binary runs
+        run: colref --version

--- a/.github/workflows/go-install-check.yml
+++ b/.github/workflows/go-install-check.yml
@@ -15,14 +15,19 @@ permissions:
 jobs:
   go-install:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
 
       - name: Install via go install
         run: go install github.com/shinagawa-web/colref/cmd/colref@latest

--- a/.github/workflows/go-install-check.yml
+++ b/.github/workflows/go-install-check.yml
@@ -1,13 +1,8 @@
 name: go-install-check
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -27,7 +22,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Install via go install
         run: go install github.com/shinagawa-web/colref/cmd/colref@latest


### PR DESCRIPTION
## Summary

- Add `.github/workflows/go-install-check.yml` triggered on push to `main` (paths: `**.go`, `go.mod`, `go.sum`)
- Runs `go install github.com/shinagawa-web/colref/cmd/colref@latest` to verify the primary Go installation path
- Verifies the installed binary runs with `colref --version`
- All actions pinned to SHA digests

Closes #90