### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub private vulnerability reporting](https://github.com/shinagawa-web/colref/security/advisories/new) to submit a report privately.
+
+## Response timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 3 business days |
+| Status update | Within 7 business days |
+| Fix or mitigation | Within 90 days |
+
+We will coordinate public disclosure with you once a fix is ready.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` at the repo root as requested in #86
- Specifies that only the latest release is supported
- Points to GitHub private vulnerability reporting for private disclosure
- Defines acknowledgement (3 days), status update (7 days), and fix (90 days) timelines

## Test plan

- [ ] Docs only — no code changes

Closes #86