### PR TITLE
docs: add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ The following directories are never scanned:
 brew install shinagawa-web/tap/colref
 ```
 
+If you prefer to tap first:
+
+```sh
+brew tap shinagawa-web/tap
+brew install colref
+```
+
 ### One-line installer (Linux and macOS)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ The following directories are never scanned:
 
 ## Installation
 
+### Homebrew (macOS and Linux)
+
+```sh
+brew install shinagawa-web/tap/colref
+```
+
 ### One-line installer (Linux and macOS)
 
 ```sh


### PR DESCRIPTION
## Summary

- Add `### Homebrew` section to `README.md` under `## Installation`
- Documents `brew install shinagawa-web/tap/colref` as an installation option

Closes #167