### PR TITLE
docs: slim down README and redirect duplicate content to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ colref scans your codebase with an AST parser, skips comments and string literal
 
 ## Installation
 
-| OS | amd64 | arm64 |
+| OS | x86_64 (Intel/AMD) | arm64 |
 |---|---|---|
 | macOS | ✓ | ✓ (Apple Silicon) |
 | Linux | ✓ | ✓ |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ colref scans your codebase with an AST parser, skips comments and string literal
 
 ## Installation
 
+| OS | amd64 | arm64 |
+|---|---|---|
+| macOS | ✓ | ✓ (Apple Silicon) |
+| Linux | ✓ | ✓ |
+| Windows | ✓ | — |
+
 ### Homebrew (macOS and Linux)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -14,83 +14,6 @@ You want to remove a column from a long-running system. The column looks unused,
 
 colref scans your codebase with an AST parser, skips comments and string literals, and tells you where the column is referenced. If it finds nothing, you have a concrete starting point for the deletion decision. The final call is yours.
 
-## Usage
-
-```
-colref check --orm <orm> --model <Model> --field <field> [path]
-```
-
-`path` is the project root to scan (default: current directory).
-
-### Django example
-
-```
-colref check --orm django --model User --field email
-```
-
-Output:
-
-```
-Scanning 142 files...
-
-No references found for User.email
-
-  Verify manually before deleting.
-```
-
-When references exist:
-
-```
-Scanning 142 files...
-
-References found for User.email
-
-  accounts/serializers.py:34   user.email
-  accounts/views.py:88         obj.email
-  notifications/tasks.py:12    instance.email
-```
-
-### Rails example
-
-```
-colref check --orm rails --model User --field email
-```
-
-colref reads `db/schema.rb` from the project root, infers model names from table names (`users` → `User`), and scans `.rb` and `.erb` files for attribute-access references.
-
-If `db/schema.rb` is not present (some projects treat it as a generated artifact and do not commit it), colref falls back to `db/migrate/`. It replays migration files in timestamp order — `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table` — to reconstruct the current schema. Model and field validation remain fully intact.
-
-### Flags
-
-| Flag | Description |
-|---|---|
-| `--orm` | ORM type: `django`, `rails` (required) |
-| `--model` | Model name to look up (required) |
-| `--field` | Field name to search for (required) |
-
-### Django — models.py detection
-
-colref locates `models.py` automatically by walking the target directory. All `models.py` files found are parsed and merged.
-
-If the same model name appears in more than one `models.py`, colref exits with an error and lists the conflicting files:
-
-```
-model "User" found in multiple files:
-  accounts/models.py
-  legacy/models.py
-Use --model to disambiguate.
-```
-
-### Skipped directories
-
-The following directories are never scanned:
-
-- `.git`, and any directory whose name starts with `.`
-- `__pycache__`
-- `venv`, `.venv`
-- `migrations`
-- `node_modules`
-
 ## Installation
 
 ### Homebrew (macOS and Linux)
@@ -112,37 +35,47 @@ brew install colref
 curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
 ```
 
-Installs the latest release binary to `/usr/local/bin`. The script detects your OS and architecture automatically, downloads the matching tarball from the [releases page](https://github.com/shinagawa-web/colref/releases), and verifies the SHA-256 checksum before installing.
-
-To install to a different directory, set `INSTALL_DIR`:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=$HOME/.local/bin sh
-```
-
 ### Manual download
 
-Pre-built binaries are also available directly on the [releases page](https://github.com/shinagawa-web/colref/releases).
+Pre-built binaries are available on the [releases page](https://github.com/shinagawa-web/colref/releases).
 
-## How it works
+For full installation options, see [Getting started](https://shinagawa-web.github.io/colref/docs/getting-started/).
 
-1. Reads your ORM schema source to extract the field list
-2. Walks the codebase and parses each file into an AST
-3. Reports every location where the field name appears as an attribute access (e.g. `user.email`)
+## Usage
 
-AST parsing avoids false positives from comments, migration files, and unrelated string matches that plain grep would surface.
+```
+colref check --orm <orm> --model <Model> --field <field> [path]
+```
+
+`path` is the project root to scan (default: current directory).
+
+| Flag | Description |
+|---|---|
+| `--orm` | ORM type: `django`, `rails` (required) |
+| `--model` | Model name to look up (required) |
+| `--field` | Field name to search for (required) |
+
+Example:
+
+```
+$ colref check --orm django --model Page --field seo_title
+Scanning 932 files...
+
+References found for Page.seo_title
+
+  wagtail/admin/tests/pages/test_create_page.py:1867   page.seo_title
+  wagtail/admin/tests/pages/test_create_page.py:1892   page.seo_title
+```
+
+For ORM-specific behavior and more examples, see [Django](https://shinagawa-web.github.io/colref/docs/usage/django/) and [Rails](https://shinagawa-web.github.io/colref/docs/usage/rails/).
 
 ## Limitations
 
 colref uses static AST analysis and cannot detect every reference pattern. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design.
 
-**Django:** attribute access, most ORM methods (`filter`, `exclude`, `get`, `Q`, `values`, `only`, `defer`, `order_by`, `F`, aggregates, etc.), and raw SQL strings are detected. Not detected: `getattr` / `attrgetter`, `update_or_create`, `save(update_fields=[...])`, `_meta.get_field`, Django admin class attributes, DRF serializer fields, and form fields.
-
-**Rails:** attribute access, most ActiveRecord query/creation/update methods (`where`, `order`, `pluck`, `create`, `update`, `find_by`, etc.), Arel subscripts, and SQL string fragments are detected. Not detected: `read_attribute`, `send`, symbol subscript (`record[:field]`), `validates` declarations, and strong parameters.
-
-For the full per-pattern breakdown, see [docs/content/docs/detection-patterns.md](docs/content/docs/detection-patterns.md).
-
 If colref reports no references, treat it as "none found by the scanner" — not as a guarantee the column is unused.
+
+For the full per-pattern breakdown, see [Detection patterns](https://shinagawa-web.github.io/colref/docs/detection-patterns/) and [Limitations](https://shinagawa-web.github.io/colref/docs/limitations/).
 
 ## Roadmap
 

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,7 +7,7 @@ weight: 10
 
 ## Installation
 
-| OS | amd64 | arm64 |
+| OS | x86_64 (Intel/AMD) | arm64 |
 |---|---|---|
 | macOS | ✓ | ✓ (Apple Silicon) |
 | Linux | ✓ | ✓ |

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,9 +7,36 @@ weight: 10
 
 ## Installation
 
-Binaries for Linux and macOS are available on the [releases page](https://github.com/shinagawa-web/colref/releases).
+### Homebrew (macOS and Linux)
 
-Download the archive for your platform, extract it, and place the `colref` binary somewhere on your `PATH`.
+```sh
+brew install shinagawa-web/tap/colref
+```
+
+If you prefer to tap first:
+
+```sh
+brew tap shinagawa-web/tap
+brew install colref
+```
+
+### One-line installer (Linux and macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
+```
+
+Installs the latest release binary to `/usr/local/bin`. The script detects your OS and architecture automatically, downloads the matching tarball from the [releases page](https://github.com/shinagawa-web/colref/releases), and verifies the SHA-256 checksum before installing.
+
+To install to a different directory, set `INSTALL_DIR`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=$HOME/.local/bin sh
+```
+
+### Manual download
+
+Pre-built binaries are also available directly on the [releases page](https://github.com/shinagawa-web/colref/releases).
 
 Verify the install:
 

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,6 +7,12 @@ weight: 10
 
 ## Installation
 
+| OS | amd64 | arm64 |
+|---|---|---|
+| macOS | ✓ | ✓ (Apple Silicon) |
+| Linux | ✓ | ✓ |
+| Windows | ✓ | — |
+
 ### Homebrew (macOS and Linux)
 
 ```sh


### PR DESCRIPTION
## Summary

- Remove README sections fully covered by the docs site: Django/Rails examples, models.py detection, Skipped directories, How it works, and Django/Rails limitation detail lists
- Add links to the docs site at each trimmed section so readers can find the full content
- Add Homebrew and one-line installer to `docs/getting-started.md`, which previously only documented manual download

Closes #173

## Test plan

- [ ] README renders correctly on GitHub — quick-start content intact, links point to the docs site
- [ ] `docs/getting-started.md` shows all three install methods (Homebrew, one-line installer, manual download)