### PR TITLE
ci: fix manylinux tag to 2_34 and run pypi job in parallel with release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           fi
 
   pypi:
-    needs: release
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -181,7 +181,7 @@ jobs:
               print('No GLIBC symbols found — static binary or objdump mismatch; skipping check')
               sys.exit(0)
           max_v = tuple(int(x) for x in max_str.split('.'))
-          limit = (2, 28)
+          limit = (2, 34)
           if max_v > limit:
               raise SystemExit(f'GLIBC_{max_str} exceeds manylinux_2_28 limit')
           print(f'GLIBC_{max_str} <= manylinux_2_28 OK')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,8 +183,8 @@ jobs:
           max_v = tuple(int(x) for x in max_str.split('.'))
           limit = (2, 34)
           if max_v > limit:
-              raise SystemExit(f'GLIBC_{max_str} exceeds manylinux_2_28 limit')
-          print(f'GLIBC_{max_str} <= manylinux_2_28 OK')
+              raise SystemExit(f'GLIBC_{max_str} exceeds manylinux_2_34 limit')
+          print(f'GLIBC_{max_str} <= manylinux_2_34 OK')
           "
 
       - name: Build wheels

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 # (goos, goarch) -> (wheel_platform_tag, bin_name)
 PLATFORMS = [
-    ("linux",   "amd64",  "manylinux_2_28_x86_64", "colref"),
-    ("linux",   "arm64",  "manylinux_2_28_aarch64", "colref"),
+    ("linux",   "amd64",  "manylinux_2_34_x86_64", "colref"),
+    ("linux",   "arm64",  "manylinux_2_34_aarch64", "colref"),
     ("darwin",  "amd64",  "macosx_10_9_x86_64",     "colref"),
     ("darwin",  "arm64",  "macosx_11_0_arm64",       "colref"),
     ("windows", "amd64",  "win_amd64",               "colref.exe"),


### PR DESCRIPTION
## Summary

- Fix `manylinux_2_28` → `manylinux_2_34` in wheel platform tags and glibc check: the linux binary built on ubuntu-latest requires GLIBC_2.34 (Go's threading functions were absorbed into libc in glibc 2.34)
- Change `pypi.needs: release` → `pypi.needs: build` so the PyPI publish runs in parallel with the GitHub Release / Homebrew update steps

## Test plan

- [ ] `v*` tag triggers the release workflow
- [ ] `pypi` job runs in parallel with `release` (not after)
- [ ] Glibc check passes for `GLIBC_2.34`
- [ ] Wheels are published to PyPI successfully

Closes #174