### PR TITLE
feat: distribute via RubyGems (gem install colref)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,3 +195,28 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist/
+
+  rubygems:
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Build gems
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ruby scripts/build_gems.rb "${VERSION}" artifacts/
+
+      - name: Push to RubyGems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          for gem in pkg/*.gem; do
+            gem push "$gem"
+          done

--- a/scripts/build_gems.rb
+++ b/scripts/build_gems.rb
@@ -38,11 +38,19 @@ RUBY
 
 ROOT = Pathname.new(__dir__).parent
 
+def normalize_version(raw_version)
+  raw_version
+    .sub(/-rc(\d+)$/,    '.rc.\1')
+    .sub(/-beta(\d+)$/,  '.beta.\1')
+    .sub(/-alpha(\d+)$/, '.alpha.\1')
+    .sub(/-pre(\d+)$/,   '.pre.\1')
+end
+
 def build_gem(raw_version, platform, artifacts_dir, out_dir)
   tarball = artifacts_dir / "colref_#{raw_version}_#{platform[:goos]}_#{platform[:goarch]}.tar.gz"
   unless tarball.exist?
-    puts "  skip #{platform[:goos]}/#{platform[:goarch]}: #{tarball.basename} not found"
-    return
+    warn "  ERROR: #{tarball.basename} not found"
+    return false
   end
 
   Dir.mktmpdir do |tmpdir|
@@ -68,7 +76,7 @@ def build_gem(raw_version, platform, artifacts_dir, out_dir)
 
     spec = Gem::Specification.new do |s|
       s.name                  = "colref"
-      s.version               = raw_version
+      s.version               = normalize_version(raw_version)
       s.platform              = platform[:gem_platform]
       s.summary               = "Check whether a database column is still referenced in your codebase before you delete it"
       s.description           = s.summary
@@ -94,6 +102,7 @@ def build_gem(raw_version, platform, artifacts_dir, out_dir)
     dest = out_dir / gem_file
     FileUtils.mv(gem_root / gem_file, dest)
     puts "  built #{dest.basename}"
+    true
   end
 end
 
@@ -101,4 +110,5 @@ raw_version = ARGV[0]&.sub(/^v/, "") or abort "Usage: #{$PROGRAM_NAME} <version>
 artifacts_dir = Pathname.new(ARGV[1] || abort("Usage: #{$PROGRAM_NAME} <version> <artifacts_dir>"))
 out_dir = Pathname.new("pkg").tap(&:mkpath)
 
-PLATFORMS.each { |p| build_gem(raw_version, p, artifacts_dir, out_dir) }
+failed = PLATFORMS.count { |p| build_gem(raw_version, p, artifacts_dir, out_dir) == false }
+abort "#{failed} platform(s) failed — aborting" if failed > 0

--- a/scripts/build_gems.rb
+++ b/scripts/build_gems.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Build platform-specific gems that embed the colref binary.
+#
+# Usage: ruby scripts/build_gems.rb <version> <artifacts_dir>
+#   version       — release tag (e.g. v0.7.4 or 0.7.4)
+#   artifacts_dir — directory containing colref_<version>_<os>_<arch>.tar.gz
+
+require "rubygems"
+require "rubygems/package"
+require "rubygems/specification"
+require "tmpdir"
+require "fileutils"
+require "pathname"
+
+PLATFORMS = [
+  { goos: "linux",   goarch: "amd64",  gem_platform: "x86_64-linux",   bin: "colref",     windows: false },
+  { goos: "linux",   goarch: "arm64",  gem_platform: "aarch64-linux",  bin: "colref",     windows: false },
+  { goos: "darwin",  goarch: "amd64",  gem_platform: "x86_64-darwin",  bin: "colref",     windows: false },
+  { goos: "darwin",  goarch: "arm64",  gem_platform: "arm64-darwin",   bin: "colref",     windows: false },
+  { goos: "windows", goarch: "amd64",  gem_platform: "x64-mingw-ucrt", bin: "colref.exe", windows: true  },
+].freeze
+
+EXE_WRAPPER_UNIX = <<~RUBY
+  #!/usr/bin/env ruby
+  # frozen_string_literal: true
+  exec File.expand_path("../libexec/colref", __dir__), *ARGV
+RUBY
+
+EXE_WRAPPER_WINDOWS = <<~RUBY
+  #!/usr/bin/env ruby
+  # frozen_string_literal: true
+  require "English"
+  system File.expand_path("../libexec/colref.exe", __dir__), *ARGV
+  exit($CHILD_STATUS.exitstatus || 1)
+RUBY
+
+ROOT = Pathname.new(__dir__).parent
+
+def build_gem(raw_version, platform, artifacts_dir, out_dir)
+  tarball = artifacts_dir / "colref_#{raw_version}_#{platform[:goos]}_#{platform[:goarch]}.tar.gz"
+  unless tarball.exist?
+    puts "  skip #{platform[:goos]}/#{platform[:goarch]}: #{tarball.basename} not found"
+    return
+  end
+
+  Dir.mktmpdir do |tmpdir|
+    tmpdir = Pathname.new(tmpdir)
+
+    system("tar", "xzf", tarball.to_s, "-C", tmpdir.to_s, platform[:bin], exception: true)
+    (tmpdir / platform[:bin]).chmod(0o755)
+
+    gem_root = tmpdir / "gem"
+    (gem_root / "exe").mkpath
+    (gem_root / "libexec").mkpath
+    (gem_root / "lib").mkpath
+
+    wrapper = platform[:windows] ? EXE_WRAPPER_WINDOWS : EXE_WRAPPER_UNIX
+    (gem_root / "exe" / "colref").write(wrapper)
+    (gem_root / "exe" / "colref").chmod(0o755)
+
+    FileUtils.cp(tmpdir / platform[:bin], gem_root / "libexec" / platform[:bin])
+    (gem_root / "libexec" / platform[:bin]).chmod(0o755)
+
+    (gem_root / "lib" / "colref.rb").write("# colref #{raw_version}\n")
+    FileUtils.cp(ROOT / "LICENSE", gem_root / "LICENSE")
+
+    spec = Gem::Specification.new do |s|
+      s.name                  = "colref"
+      s.version               = raw_version
+      s.platform              = platform[:gem_platform]
+      s.summary               = "Check whether a database column is still referenced in your codebase before you delete it"
+      s.description           = s.summary
+      s.homepage              = "https://github.com/shinagawa-web/colref"
+      s.license               = "MIT"
+      s.authors               = ["Kazutomo Deguchi"]
+      s.bindir                = "exe"
+      s.executables           = ["colref"]
+      s.files                 = ["exe/colref", "libexec/#{platform[:bin]}", "lib/colref.rb", "LICENSE"]
+      s.require_paths         = ["lib"]
+      s.required_ruby_version = ">= 3.1"
+      s.metadata = {
+        "source_code_uri" => "https://github.com/shinagawa-web/colref",
+        "bug_tracker_uri" => "https://github.com/shinagawa-web/colref/issues",
+      }
+    end
+
+    gem_file = nil
+    Dir.chdir(gem_root) do
+      gem_file = Gem::Package.build(spec)
+    end
+
+    dest = out_dir / gem_file
+    FileUtils.mv(gem_root / gem_file, dest)
+    puts "  built #{dest.basename}"
+  end
+end
+
+raw_version = ARGV[0]&.sub(/^v/, "") or abort "Usage: #{$PROGRAM_NAME} <version> <artifacts_dir>"
+artifacts_dir = Pathname.new(ARGV[1] || abort("Usage: #{$PROGRAM_NAME} <version> <artifacts_dir>"))
+out_dir = Pathname.new("pkg").tap(&:mkpath)
+
+PLATFORMS.each { |p| build_gem(raw_version, p, artifacts_dir, out_dir) }


### PR DESCRIPTION
## Summary

- Adds `scripts/build_gems.rb` — builds platform-specific gems from release tarballs
- Adds `rubygems` job to `release.yml` — runs after GitHub Release, pushes gems to RubyGems.org

## How it works

Each gem bundles the pre-compiled binary in `libexec/` and a thin Ruby wrapper in `exe/colref`:

```ruby
exec File.expand_path("../libexec/colref", __dir__), *ARGV
```

No Go installation required for users.

| Platform gem | Binary |
|---|---|
| `x86_64-linux` | `colref` (linux/amd64) |
| `aarch64-linux` | `colref` (linux/arm64) |
| `x86_64-darwin` | `colref` (darwin/amd64) |
| `arm64-darwin` | `colref` (darwin/arm64) |
| `x64-mingw-ucrt` | `colref.exe` (windows/amd64, Ruby ≥ 3.1) |

## Before merging

Set `RUBYGEMS_API_KEY` in GitHub repository secrets (Settings → Secrets → Actions).

To get the key: rubygems.org → Profile → Edit Profile → API Keys → New API Key (push gems scope).

## Test plan

- [ ] `RUBYGEMS_API_KEY` secret is set
- [ ] Trigger a release tag and confirm all 5 gems appear on rubygems.org

Closes #81