### PR TITLE
docs: add pip/pipx installation instructions to README and getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ The following directories are never scanned:
 
 ## Installation
 
+### pip / pipx (Python users)
+
+If you are working on a Django or Python project, the easiest way to install colref is via pip or pipx. No Go installation required.
+
+```sh
+pipx install colref
+```
+
+Or with pip:
+
+```sh
+pip install colref
+```
+
+Wheels are available for Linux (x86\_64, aarch64), macOS (x86\_64, arm64), and Windows (x86\_64).
+
 ### Homebrew (macOS and Linux)
 
 ```sh

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,9 +7,35 @@ weight: 10
 
 ## Installation
 
-Binaries for Linux and macOS are available on the [releases page](https://github.com/shinagawa-web/colref/releases).
+### pip / pipx (Python users)
 
-Download the archive for your platform, extract it, and place the `colref` binary somewhere on your `PATH`.
+If you are working on a Django or Python project, install via pipx or pip. No Go installation required.
+
+```sh
+pipx install colref
+```
+
+Or with pip:
+
+```sh
+pip install colref
+```
+
+### Homebrew (macOS and Linux)
+
+```sh
+brew install shinagawa-web/tap/colref
+```
+
+### One-line installer (Linux and macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
+```
+
+### Manual download
+
+Pre-built binaries are available on the [releases page](https://github.com/shinagawa-web/colref/releases).
 
 Verify the install:
 


### PR DESCRIPTION
## Summary

- Add `pip` / `pipx` installation section to `README.md` as the first method under Installation (Django/Python users are the primary audience)
- Update `docs/content/docs/getting-started.md` with the same, replacing the sparse "download from releases" placeholder with all installation methods

## Changes

Both files now lead with:

\`\`\`sh
pipx install colref
\`\`\`

Followed by Homebrew, the one-line installer, and manual download.

Closes #178