### PR TITLE
ci: add PyPI and RubyGems jobs to verify-distribution workflow

### DIFF
--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -36,6 +36,48 @@ jobs:
           fi
           echo "OK: $installed"
 
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install via pip
+        run: pip install colref
+
+      - name: Verify version matches latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          expected=$(gh release view --repo shinagawa-web/colref --json tagName -q .tagName)
+          expected_no_v="${expected#v}"
+          installed=$(pip show colref | awk '/^Version:/ {print $2}')
+          echo "Expected : $expected_no_v"
+          echo "Installed: $installed"
+          if [ "$installed" != "$expected_no_v" ]; then
+            echo "ERROR: version mismatch"
+            exit 1
+          fi
+          echo "OK: $installed"
+
+  rubygems:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install via gem
+        run: gem install colref
+
+      - name: Verify version matches latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          expected=$(gh release view --repo shinagawa-web/colref --json tagName -q .tagName)
+          expected_no_v="${expected#v}"
+          installed=$(gem list colref --local | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "Expected : $expected_no_v"
+          echo "Installed: $installed"
+          if [ "$installed" != "$expected_no_v" ]; then
+            echo "ERROR: version mismatch"
+            exit 1
+          fi
+          echo "OK: $installed"
+
   homebrew:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -61,7 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install via gem
-        run: gem install colref
+        run: |
+          gem install colref --user-install
+          echo "$(ruby -e 'puts Gem.user_dir')/bin" >> "$GITHUB_PATH"
 
       - name: Verify version matches latest release
         env:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ pip install colref
 | Linux | ✓ | ✓ |
 | Windows | ✓ | — |
 
+### gem (Ruby users)
+
+If you are working on a Rails or Ruby project, install via gem. No Go installation required.
+
+```sh
+gem install colref
+```
+
 ### Homebrew (macOS and Linux)
 
 ```sh

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -27,6 +27,14 @@ Or with pip:
 pip install colref
 ```
 
+### gem (Ruby users)
+
+If you are working on a Rails or Ruby project, install via gem. No Go installation required.
+
+```sh
+gem install colref
+```
+
 ### Homebrew (macOS and Linux)
 
 ```sh


### PR DESCRIPTION
## Summary

- Add `pypi` job to `verify-distribution.yml`: installs via `pip install colref` and verifies the installed version matches the latest GitHub Release tag
- Add `rubygems` job to `verify-distribution.yml`: installs via `gem install colref` and verifies the same
- Add `gem install colref` instructions to README and `docs/getting-started.md`

Both jobs follow the same pattern as the existing `go-install` and `homebrew` jobs.

Closes #171

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm all four jobs pass
- [ ] README and `docs/getting-started.md` render the gem install section correctly