### PR TITLE
feat(django): detect getattr() and attrgetter() field references

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -5,7 +5,7 @@ weight: 40
 
 # Detection patterns
 
-colref uses static AST analysis. It can only detect patterns where the field name appears as a literal in the source. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design — static analysis cannot determine what string `field_name` holds.
+colref uses static AST analysis. It can only detect patterns where the field name appears as a literal in the source. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design — static analysis cannot determine what string `field_name` holds at runtime.
 
 This page documents exactly which patterns are and are not detected for each ORM. The ground truth is the golden test files in `test_patterns/`.
 
@@ -17,6 +17,7 @@ All three mean the reference was detected. The label indicates how it was found 
 |--------|-----------|------------|
 | ✅ | AST attribute node (`article.title`) | Highest — unambiguous |
 | ✅ `[string]` | Literal string or symbol passed to a known ORM method (`.where(title: value)`, `.pluck(:title)`) | High — method is known to accept field names |
+| ✅ `[getattr]` | Literal string in `getattr(obj, "field")` or `attrgetter("field")` | Lower — built-in, not model-specific; verify manually |
 | ✅ `[sql ref]` | Word-boundary substring match inside a raw SQL string (`.where("title = ?", value)`) | Lower — verify manually, false positives possible |
 
 ## Django {#django}
@@ -38,6 +39,21 @@ All three mean the reference was detected. The label indicates how it was found 
 | Augmented write | `article.title += " suffix"` | ✅ |
 
 colref makes no read/write distinction — both are matched as attribute nodes.
+
+</details>
+
+<details>
+<summary>getattr / attrgetter</summary>
+
+The field name appears as a string literal. The `[getattr]` label signals lower confidence because `getattr` and `attrgetter` are general Python built-ins, not model-specific calls — any object with a matching attribute name will be reported.
+
+| Pattern | Example | Result |
+|---------|---------|--------|
+| `getattr` literal | `getattr(article, "title")` | ✅ `[getattr]` |
+| `getattr` with default | `getattr(article, "title", "")` | ✅ `[getattr]` |
+| `attrgetter` | `attrgetter("title")(article)` | ✅ `[getattr]` |
+| `operator.attrgetter` | `operator.attrgetter("title")` | ✅ `[getattr]` |
+| `getattr` with variable | `getattr(article, field_name)` | ❌ out of scope — field name not statically visible |
 
 </details>
 
@@ -105,18 +121,6 @@ The field name appears as the first positional string argument.
 </details>
 
 ### Not detected
-
-<details>
-<summary>getattr / attrgetter</summary>
-
-| Pattern | Example | Result |
-|---------|---------|--------|
-| `getattr` with literal | `getattr(article, "title")` | ❌ |
-| `getattr` with default | `getattr(article, "title", "")` | ❌ |
-| `attrgetter` | `attrgetter("title")(article)` | ❌ |
-| `getattr` with variable | `getattr(article, field_name)` | ❌ out of scope by design |
-
-</details>
 
 <details>
 <summary>ORM — uncovered methods</summary>

--- a/docs/content/docs/limitations.md
+++ b/docs/content/docs/limitations.md
@@ -11,9 +11,9 @@ colref uses static AST analysis and cannot detect every reference pattern. Refer
 
 ## Django
 
-Detected: attribute access, most ORM methods (`filter`, `exclude`, `get`, `Q`, `values`, `only`, `defer`, `order_by`, `F`, aggregates, etc.), and raw SQL strings.
+Detected: attribute access, `getattr(obj, "field")` / `attrgetter("field")` (labeled `[getattr]`), most ORM methods (`filter`, `exclude`, `get`, `Q`, `values`, `only`, `defer`, `order_by`, `F`, aggregates, etc.), and raw SQL strings.
 
-Not detected: `getattr` / `attrgetter`, `update_or_create`, `save(update_fields=[...])`, `_meta.get_field`, Django admin class attributes, DRF serializer fields, and form fields.
+Not detected: `getattr` with variable field name, `update_or_create`, `save(update_fields=[...])`, `_meta.get_field`, Django admin class attributes, DRF serializer fields, and form fields.
 
 ## Rails
 

--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -167,6 +167,36 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 							break
 						}
 					}
+				case methodName == "getattr":
+					// Second positional arg is the field name string.
+					// Variable-arg form getattr(obj, field_var) is not detected.
+					pos := 0
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						t := child.Type()
+						if t == "," || t == "(" || t == ")" || t == "keyword_argument" {
+							continue
+						}
+						if pos == 1 {
+							if t == "string" && stringContent(child, src) == fieldName {
+								addGetAttrRef(child, lines, file, refs)
+							}
+							break
+						}
+						pos++
+					}
+				case methodName == "attrgetter":
+					// First positional arg is the field name string.
+					// Works for attrgetter('field') and operator.attrgetter('field').
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() == "string" {
+							if stringContent(child, src) == fieldName {
+								addGetAttrRef(child, lines, file, refs)
+							}
+							break
+						}
+					}
 				}
 			}
 		}
@@ -208,6 +238,16 @@ func addStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Refere
 		File: file,
 		Line: row + 1,
 		Text: "[string] " + strings.TrimSpace(lineAt(lines, row)),
+	})
+}
+
+// addGetAttrRef appends a [getattr]-labeled Reference using the node's source row.
+func addGetAttrRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
+	row := int(node.StartPoint().Row)
+	*refs = append(*refs, Reference{
+		File: file,
+		Line: row + 1,
+		Text: "[getattr] " + strings.TrimSpace(lineAt(lines, row)),
 	})
 }
 

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -462,7 +462,8 @@ func TestScan_QObject_NotDetected(t *testing.T) {
 
 func TestScan_GetAttr_NotDetected(t *testing.T) {
 	dir := t.TempDir()
-	// v0.1 limitation: getattr() takes the field name as a string.
+	// Attribute-access scan does not cover call nodes; getattr() is detected
+	// by ScanStringRefs instead (with a [getattr] label).
 	writeFile(t, dir, "views.py", `v = getattr(user, "email")`)
 
 	refs, _, err := Scan(dir, "email")
@@ -470,7 +471,7 @@ func TestScan_GetAttr_NotDetected(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(refs) != 0 {
-		t.Errorf("getattr() should not be detected in v0.1, got %d: %v", len(refs), refs)
+		t.Errorf("Scan() should not detect getattr(), got %d: %v", len(refs), refs)
 	}
 }
 
@@ -657,17 +658,87 @@ func TestScanStringRefs_FExpression(t *testing.T) {
 	}
 }
 
-func TestScanStringRefs_GetAttrNotDetected(t *testing.T) {
+func TestScanStringRefs_GetAttr_TwoArgs(t *testing.T) {
 	dir := t.TempDir()
-	// getattr() is not a Django ORM method — should not be detected.
 	writeFile(t, dir, "views.py", `v = getattr(user, "email")`)
 
 	refs, _, err := ScanStringRefs(dir, "email")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for getattr(), got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[getattr] ") {
+		t.Errorf("want [getattr] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_GetAttr_ThreeArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `v = getattr(user, "email", "")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for getattr() with default, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_GetAttr_VariableArg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `v = getattr(user, field_name)`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(refs) != 0 {
-		t.Errorf("getattr() should not be detected by ScanStringRefs, got %d: %v", len(refs), refs)
+		t.Errorf("getattr() with variable arg should not be detected, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_GetAttr_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `v = getattr(user, "name")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("getattr() for different field should not match, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_AttrGetter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `f = attrgetter("email"); result = f(user)`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for attrgetter(), got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[getattr] ") {
+		t.Errorf("want [getattr] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_AttrGetter_QualifiedImport(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `import operator; f = operator.attrgetter("email")`)
+
+	refs, _, err := ScanStringRefs(dir, "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for operator.attrgetter(), got %d: %v", len(refs), refs)
 	}
 }
 

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -10,6 +10,9 @@ References found for Article.title
   references.py:37   a.title
   references.py:40   article.title
   references.py:41   article.title
+  references.py:44   [getattr] x = getattr(article, 'title')                          # getattr literal
+  references.py:45   [getattr] x = getattr(article, 'title', '')                      # getattr with default
+  references.py:46   [getattr] x = operator.attrgetter('title')(article)              # attrgetter
   references.py:50   [string] qs = Article.objects.filter(title='x')                 # filter keyword
   references.py:51   [string] qs = Article.objects.filter(title__icontains='x')      # filter lookup
   references.py:52   [string] qs = Article.objects.exclude(title='x')                # exclude


### PR DESCRIPTION
Closes #112

## Summary

- `getattr(obj, 'field')` and `getattr(obj, 'field', default)` are now detected
- `attrgetter('field')` and `operator.attrgetter('field')` are now detected
- Variable-argument form `getattr(obj, field_var)` is correctly excluded (field name not a static literal)
- Results carry a `[getattr]` label to signal lower confidence, consistent with how `[string]` marks ORM string refs

## Test plan

- [ ] `TestScan_GetAttr_NotDetected` — verifies `Scan()` (attribute-access only) does not pick up `getattr()`
- [ ] `TestScanStringRefs_GetAttr_TwoArgs` — basic two-arg form
- [ ] `TestScanStringRefs_GetAttr_ThreeArgs` — three-arg form with default value
- [ ] `TestScanStringRefs_GetAttr_VariableArg_NotDetected` — dynamic key not detected
- [ ] `TestScanStringRefs_GetAttr_WrongField_NotDetected` — different field not matched
- [ ] `TestScanStringRefs_AttrGetter` — bare `attrgetter()`
- [ ] `TestScanStringRefs_AttrGetter_QualifiedImport` — `operator.attrgetter()`
- [ ] `TestE2E_PatternBattery_Django` — golden file updated with three new `[getattr]` entries