### PR TITLE
feat(django): detect save(update_fields=[...]) references

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -111,6 +111,19 @@ The field name appears as the first positional string argument.
 </details>
 
 <details>
+<summary>save with update_fields</summary>
+
+The field name appears as a string element inside the `update_fields` list passed to `Model.save()`.
+
+| Pattern | Example | Result |
+|---------|---------|--------|
+| Single field | `article.save(update_fields=["title"])` | ✅ `[string]` |
+| Multiple fields | `article.save(update_fields=["title", "slug"])` | ✅ `[string]` |
+| Variable list | `article.save(update_fields=fields)` | ❌ out of scope — list not statically visible |
+
+</details>
+
+<details>
 <summary>Raw SQL</summary>
 
 | Method | Example | Result |
@@ -128,7 +141,6 @@ The field name appears as the first positional string argument.
 | Pattern | Example | Result |
 |---------|---------|--------|
 | `update_or_create` | `.update_or_create(defaults={"title": "x"})` | ❌ |
-| `save` with `update_fields` | `article.save(update_fields=["title"])` | ❌ |
 
 </details>
 

--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -197,6 +197,28 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 							break
 						}
 					}
+				case methodName == "save":
+					// article.save(update_fields=['title', 'slug'])
+					for i := 0; i < int(args.ChildCount()); i++ {
+						child := args.Child(i)
+						if child.Type() != "keyword_argument" {
+							continue
+						}
+						nameNode := child.ChildByFieldName("name")
+						if nameNode == nil || nameNode.Content(src) != "update_fields" {
+							continue
+						}
+						val := child.ChildByFieldName("value")
+						if val == nil || val.Type() != "list" {
+							continue
+						}
+						for j := 0; j < int(val.ChildCount()); j++ {
+							elem := val.Child(j)
+							if elem.Type() == "string" && stringContent(elem, src) == fieldName {
+								addStringRef(elem, lines, file, refs)
+							}
+						}
+					}
 				}
 			}
 		}

--- a/internal/refs/django.go
+++ b/internal/refs/django.go
@@ -197,7 +197,7 @@ func walkNodeStringRefs(node *sitter.Node, src []byte, lines [][]byte, fieldName
 							break
 						}
 					}
-				case methodName == "save":
+				case methodName == "save" && fn.Type() == "attribute":
 					// article.save(update_fields=['title', 'slug'])
 					for i := 0; i < int(args.ChildCount()); i++ {
 						child := args.Child(i)

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1813,6 +1813,32 @@ func TestScanStringRefs_SaveUpdateFields_WrongField_NotDetected(t *testing.T) {
 	}
 }
 
+func TestScanStringRefs_SaveOtherKwarg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save(force_insert=True)`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for non-update_fields kwarg, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_SaveUpdateFields_NonListValue_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save(update_fields=my_list)`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for non-list update_fields value, got %d: %v", len(refs), refs)
+	}
+}
+
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
 // per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
 // in line density while exceeding it in file count.

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1839,6 +1839,19 @@ func TestScanStringRefs_SaveUpdateFields_NonListValue_NotDetected(t *testing.T) 
 	}
 }
 
+func TestScanStringRefs_SaveUpdateFields_StandaloneFunction_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `save(update_fields=['title'])`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for standalone save() function, got %d: %v", len(refs), refs)
+	}
+}
+
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
 // per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
 // in line density while exceeding it in file count.

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -1748,6 +1748,71 @@ func TestScanStringRefs_SQLParseError(t *testing.T) {
 	}
 }
 
+// --- save(update_fields=[...]) tests ---
+
+func TestScanStringRefs_SaveUpdateFields_Single(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save(update_fields=['title'])`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanStringRefs_SaveUpdateFields_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save(update_fields=['title', 'slug'])`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref for 'title', got %d: %v", len(refs), refs)
+	}
+
+	refs2, _, err := ScanStringRefs(dir, "slug")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs2) != 1 {
+		t.Fatalf("want 1 ref for 'slug', got %d: %v", len(refs2), refs2)
+	}
+}
+
+func TestScanStringRefs_SaveNoUpdateFields_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save()`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for save() without update_fields, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanStringRefs_SaveUpdateFields_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "views.py", `article.save(update_fields=['slug'])`)
+
+	refs, _, err := ScanStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for wrong field, got %d: %v", len(refs), refs)
+	}
+}
+
 // BenchmarkScan uses 1,000 Python files (200 apps × 5 files, ~100 lines each) with
 // per-app generated names — comparable to BookWyrm scale (~433 files, ~52k lines)
 // in line density while exceeding it in file count.

--- a/test_patterns/django/golden_title.txt
+++ b/test_patterns/django/golden_title.txt
@@ -37,5 +37,6 @@ References found for Article.title
   references.py:77   [string] expr = Coalesce('title', Value(''))                    # Coalesce
   references.py:78   [string] expr = Concat('title', Value(' - '))                   # Concat
   references.py:79   [string] expr = OuterRef('title')                               # OuterRef
+  references.py:82   [string] article.save(update_fields=['title'])                  # update_fields
   references.py:97   [sql ref] qs = Article.objects.raw("SELECT title FROM article WHERE slug = %s", [slug])  # raw()
   references.py:99   [sql ref] cursor.execute("SELECT title, slug FROM article WHERE active = 1")         # cursor.execute


### PR DESCRIPTION
## Summary

- Adds detection of `article.save(update_fields=['title'])` patterns as `[string]` references
- Handles multiple fields: `save(update_fields=['title', 'slug'])` detects each field independently
- No false positives for `save()` without `update_fields`, or when `update_fields` value is not a list literal

## Implementation

New `case methodName == "save"` branch in `walkNodeStringRefs` (`internal/refs/django.go`): scans keyword arguments for `update_fields`, then walks each string element of the list.

## Test plan

- [x] Unit tests: single field, multiple fields, no `update_fields`, wrong field, non-list value, other keyword arg
- [x] Pattern battery: `references.py:82` added to `golden_title.txt`
- [x] Coverage: 100%

Closes #113