### PR TITLE
feat(rails): support db/structure.sql as schema source

### DIFF
--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -57,6 +57,10 @@ var parseModelsWithSet = schema.ParseModelsWithSet
 // It is a var so tests can inject a failing version to cover error paths.
 var parseSchemaRb = schema.ParseSchemaRb
 
+// parseStructureSql is the function used to parse a db/structure.sql source file.
+// It is a var so tests can inject a failing version to cover error paths.
+var parseStructureSql = schema.ParseStructureSql
+
 // parseMigrations is the function used to parse db/migrate/ files.
 // It is a var so tests can inject a failing version to cover error paths.
 var parseMigrations = schema.ParseMigrations
@@ -77,19 +81,36 @@ func runCheck(dir, modelName, fieldName, ormName string) error {
 }
 
 func runCheckRails(dir, modelName, fieldName string) error {
+	// 1. db/schema.rb (preferred).
 	schemaFile := filepath.Join(dir, "db", "schema.rb")
 	src, err := os.ReadFile(schemaFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return runCheckRailsMigrations(dir, modelName, fieldName)
+	if err == nil {
+		fields, err := parseSchemaRb(src)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", schemaFile, err)
 		}
+		return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", schemaFile, err)
 	}
-	fields, err := parseSchemaRb(src)
-	if err != nil {
-		return fmt.Errorf("parse %s: %w", schemaFile, err)
+
+	// 2. db/structure.sql (used when config.active_record.schema_format = :sql).
+	structureFile := filepath.Join(dir, "db", "structure.sql")
+	src, err = os.ReadFile(structureFile)
+	if err == nil {
+		fields, err := parseStructureSql(src)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", structureFile, err)
+		}
+		return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
 	}
-	return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", structureFile, err)
+	}
+
+	// 3. db/migrate/ (fallback when no schema dump is present).
+	return runCheckRailsMigrations(dir, modelName, fieldName)
 }
 
 func runCheckRailsMigrations(dir, modelName, fieldName string) error {

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -654,6 +654,109 @@ func TestRunCheck_Rails_ParseError(t *testing.T) {
 	}
 }
 
+func setupRailsStructureFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "structure.sql"), []byte(`
+CREATE TABLE "users" (
+  "id" bigint NOT NULL,
+  "email" character varying NOT NULL,
+  "name" character varying
+);
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.rb"), []byte(`user.email`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestRunCheck_Rails_StructureSql_RefsFound(t *testing.T) {
+	// No schema.rb: falls through to structure.sql.
+	dir := setupRailsStructureFixture(t)
+	if err := runCheck(dir, "User", "email", "rails"); err != nil {
+		t.Fatalf("structure.sql path should not error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_StructureSql_SchemaRbWins(t *testing.T) {
+	// Both schema.rb and structure.sql present: schema.rb takes priority.
+	dir := setupRailsFixture(t)
+	dbDir := filepath.Join(dir, "db")
+	// Write a structure.sql with a different model so we can tell which was used.
+	if err := os.WriteFile(filepath.Join(dbDir, "structure.sql"), []byte(`
+CREATE TABLE "posts" (
+  "id" bigint NOT NULL,
+  "title" character varying
+);
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// schema.rb defines User; structure.sql defines Post.
+	// If schema.rb wins, "User"/"email" should be found.
+	if err := runCheck(dir, "User", "email", "rails"); err != nil {
+		t.Fatalf("schema.rb should win over structure.sql: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_StructureSql_FallsBackToMigrations(t *testing.T) {
+	// No schema.rb, no structure.sql: falls back to db/migrate/.
+	dir := setupRailsMigrationsFixture(t)
+	if err := runCheck(dir, "User", "email", "rails"); err != nil {
+		t.Fatalf("migrations fallback should not error: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_StructureSql_ReadError(t *testing.T) {
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sqlPath := filepath.Join(dbDir, "structure.sql")
+	if err := os.WriteFile(sqlPath, []byte("-- sql"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sqlPath, 0o644) })
+
+	err := runCheck(dir, "User", "email", "rails")
+	if err == nil {
+		t.Fatal("expected error for unreadable structure.sql")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("expected 'read' in error, got: %v", err)
+	}
+}
+
+func TestRunCheck_Rails_StructureSql_ParseError(t *testing.T) {
+	orig := parseStructureSql
+	parseStructureSql = func(src []byte) ([]schema.Field, error) {
+		return nil, fmt.Errorf("injected structure.sql parse error")
+	}
+	defer func() { parseStructureSql = orig }()
+
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "structure.sql"), []byte("-- sql"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runCheck(dir, "User", "email", "rails")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "injected structure.sql parse error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestCheckCmd_RunE_WithArg(t *testing.T) {
 	dir := setupDjangoFixture(t)
 

--- a/docs/content/docs/how-it-works.md
+++ b/docs/content/docs/how-it-works.md
@@ -17,7 +17,7 @@ AST parsing avoids false positives from comments, migration files, and unrelated
 
 **Django** — colref walks the target directory to find `models.py` files. Each file is parsed and the field list for the requested model is extracted. If the same model name appears in multiple files, colref exits with an error.
 
-**Rails** — colref reads `db/schema.rb` and maps table names to model names by convention (`users` → `User`). If `db/schema.rb` is absent, colref falls back to replaying `db/migrate/` in timestamp order, applying `create_table`, `add_column`, `remove_column`, `rename_column`, and `drop_table` operations to reconstruct the live schema.
+**Rails** — colref looks for a schema source in order: `db/schema.rb` → `db/structure.sql` → `db/migrate/`. Table names are mapped to model names by convention (`users` → `User`). `db/structure.sql` is used by projects that set `config.active_record.schema_format = :sql`. The migrations fallback replays `create_table`, `add_column`, `remove_column`, `rename_column`, and `drop_table` operations in timestamp order to reconstruct the live schema.
 
 ## AST scanning
 

--- a/docs/content/docs/usage/rails.md
+++ b/docs/content/docs/usage/rails.md
@@ -35,9 +35,13 @@ References found for Account.memorial
 
 ## Schema source
 
-colref first looks for `db/schema.rb`. If present, it extracts the current column list from there.
+colref looks for a schema source in the following order:
 
-If `db/schema.rb` is not present (some projects treat it as a generated artifact and do not commit it), colref falls back to `db/migrate/`. It replays migration files in timestamp order — `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table` — to reconstruct the current schema. Model and field validation remain fully intact.
+1. **`db/schema.rb`** — the standard Rails schema dump (`:ruby` format). Present in most projects.
+2. **`db/structure.sql`** — used when `config.active_record.schema_format = :sql` (PostgreSQL-specific features such as custom types, partial indexes, or materialized views that `schema.rb` cannot represent). Supports PostgreSQL, MySQL, and SQLite quoting styles.
+3. **`db/migrate/`** — fallback when no schema dump is committed. colref replays migration files in timestamp order — `create_table`, `add_column`, `remove_column`, `rename_column`, `drop_table` — to reconstruct the current schema.
+
+Model and field validation are fully intact regardless of which source is used.
 
 ## Detection coverage
 

--- a/internal/schema/rails_structure.go
+++ b/internal/schema/rails_structure.go
@@ -1,0 +1,214 @@
+package schema
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// ParseStructureSql parses a Rails db/structure.sql file and returns all
+// column definitions as Fields. It recognises CREATE TABLE blocks and
+// ALTER TABLE … ADD COLUMN statements. The Model name is derived from the
+// table name using the same singularize+CamelCase heuristic as ParseSchemaRb.
+//
+// Supported quoting styles: double-quoted ("col"), backtick-quoted (`col`),
+// and unquoted. Optional schema prefixes (e.g. public.users) are stripped.
+func ParseStructureSql(src []byte) ([]Field, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(src))
+	var fields []Field
+
+	inTable := false
+	currentModel := ""
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		upper := strings.ToUpper(trimmed)
+
+		if !inTable {
+			switch {
+			case strings.HasPrefix(upper, "CREATE TABLE"):
+				if name := sqlExtractCreateTableName(trimmed); name != "" {
+					currentModel = tableToModel(name)
+					inTable = true
+				}
+			case strings.HasPrefix(upper, "ALTER TABLE"):
+				table, col := sqlExtractAlterAddColumn(trimmed)
+				if table != "" && col != "" {
+					fields = append(fields, Field{Model: tableToModel(table), Name: col})
+				}
+			}
+			continue
+		}
+
+		// Inside a CREATE TABLE block.
+		if strings.HasPrefix(trimmed, ")") {
+			inTable = false
+			currentModel = ""
+			continue
+		}
+		if sqlIsConstraintLine(upper) {
+			continue
+		}
+		if col := sqlFirstIdent(trimmed); col != "" {
+			fields = append(fields, Field{Model: currentModel, Name: col})
+		}
+	}
+
+	return fields, scanner.Err()
+}
+
+// sqlExtractCreateTableName extracts the bare table name from a
+// "CREATE TABLE [IF NOT EXISTS] [schema.]name (" line.
+func sqlExtractCreateTableName(line string) string {
+	upper := strings.ToUpper(line)
+	idx := strings.Index(upper, "CREATE TABLE")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(line[idx+len("CREATE TABLE"):])
+
+	// Strip optional IF NOT EXISTS.
+	if up := strings.ToUpper(rest); strings.HasPrefix(up, "IF NOT EXISTS") {
+		rest = strings.TrimSpace(rest[len("IF NOT EXISTS"):])
+	}
+
+	// First identifier may be the schema prefix.
+	ident1, rest2 := sqlNextIdent(rest)
+	if ident1 == "" {
+		return ""
+	}
+
+	// If followed by '.', the real table name is the next identifier.
+	if len(strings.TrimSpace(rest2)) > 0 && strings.TrimSpace(rest2)[0] == '.' {
+		rest2 = strings.TrimSpace(rest2)[1:]
+		if ident2, _ := sqlNextIdent(rest2); ident2 != "" {
+			return ident2
+		}
+	}
+
+	return ident1
+}
+
+// sqlExtractAlterAddColumn extracts the table name and column name from an
+// "ALTER TABLE [ONLY] [schema.]table ADD [COLUMN] [IF NOT EXISTS] col …" line.
+// Returns ("", "") if the line is not a matching ADD COLUMN statement.
+func sqlExtractAlterAddColumn(line string) (table, col string) {
+	upper := strings.ToUpper(line)
+	idx := strings.Index(upper, "ALTER TABLE")
+	if idx < 0 {
+		return "", ""
+	}
+	rest := strings.TrimSpace(line[idx+len("ALTER TABLE"):])
+
+	// Strip optional ONLY.
+	if up := strings.ToUpper(rest); strings.HasPrefix(up, "ONLY") &&
+		(len(up) == 4 || !sqlIsWordByte(up[4])) {
+		rest = strings.TrimSpace(rest[4:])
+	}
+
+	// Extract table name (handle schema.table).
+	ident1, rest2 := sqlNextIdent(rest)
+	if ident1 == "" {
+		return "", ""
+	}
+	rest2 = strings.TrimSpace(rest2)
+	if len(rest2) > 0 && rest2[0] == '.' {
+		if ident2, r := sqlNextIdent(strings.TrimSpace(rest2[1:])); ident2 != "" {
+			table, rest2 = ident2, r
+		} else {
+			table = ident1
+		}
+	} else {
+		table = ident1
+	}
+
+	// Find the ADD keyword. Trim rest2 first so addIdx indexes into it correctly.
+	rest2 = strings.TrimSpace(rest2)
+	up2 := strings.ToUpper(rest2)
+	addIdx := strings.Index(up2, "ADD")
+	if addIdx < 0 || (addIdx+3 < len(up2) && sqlIsWordByte(up2[addIdx+3])) {
+		return "", ""
+	}
+	rest3 := strings.TrimSpace(rest2[addIdx+3:])
+
+	// Strip optional COLUMN.
+	if up3 := strings.ToUpper(rest3); strings.HasPrefix(up3, "COLUMN") &&
+		(len(up3) == 6 || !sqlIsWordByte(up3[6])) {
+		rest3 = strings.TrimSpace(rest3[6:])
+	}
+
+	// Strip optional IF NOT EXISTS.
+	if up3 := strings.ToUpper(rest3); strings.HasPrefix(up3, "IF NOT EXISTS") {
+		rest3 = strings.TrimSpace(rest3[len("IF NOT EXISTS"):])
+	}
+
+	// Skip non-column ADD clauses: ADD CONSTRAINT, ADD PRIMARY KEY, etc.
+	up3 := strings.ToUpper(rest3)
+	for _, kw := range []string{"CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "INDEX"} {
+		if strings.HasPrefix(up3, kw) && (len(up3) == len(kw) || !sqlIsWordByte(up3[len(kw)])) {
+			return "", ""
+		}
+	}
+
+	col, _ = sqlNextIdent(rest3)
+	return table, col
+}
+
+// sqlNextIdent returns the first SQL identifier from s (double-quoted, backtick-
+// quoted, or a plain word) and the remaining string after it.
+func sqlNextIdent(s string) (ident, rest string) {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return "", ""
+	}
+	switch s[0] {
+	case '"':
+		end := strings.IndexByte(s[1:], '"')
+		if end < 0 {
+			return "", ""
+		}
+		return s[1 : end+1], s[end+2:]
+	case '`':
+		end := strings.IndexByte(s[1:], '`')
+		if end < 0 {
+			return "", ""
+		}
+		return s[1 : end+1], s[end+2:]
+	default:
+		end := strings.IndexAny(s, " \t\n\r(),;.")
+		if end < 0 {
+			return s, ""
+		}
+		return s[:end], s[end:]
+	}
+}
+
+// sqlFirstIdent returns the first identifier from a column-definition line.
+// It is the column name for lines inside a CREATE TABLE block.
+func sqlFirstIdent(line string) string {
+	name, _ := sqlNextIdent(strings.TrimSpace(line))
+	return name
+}
+
+// sqlConstraintPrefixes are keywords that start a table constraint line
+// inside a CREATE TABLE block (not a column definition).
+var sqlConstraintPrefixes = []string{
+	"PRIMARY", "UNIQUE", "KEY", "CONSTRAINT", "FOREIGN", "INDEX", "CHECK", "EXCLUDE",
+}
+
+// sqlIsConstraintLine reports whether an upper-cased, trimmed line is a
+// table constraint rather than a column definition.
+func sqlIsConstraintLine(upperTrimmed string) bool {
+	for _, kw := range sqlConstraintPrefixes {
+		if strings.HasPrefix(upperTrimmed, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// sqlIsWordByte reports whether b is an ASCII identifier character.
+func sqlIsWordByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_'
+}

--- a/internal/schema/rails_structure.go
+++ b/internal/schema/rails_structure.go
@@ -13,8 +13,14 @@ import (
 //
 // Supported quoting styles: double-quoted ("col"), backtick-quoted (`col`),
 // and unquoted. Optional schema prefixes (e.g. public.users) are stripped.
+// sqlMaxLineBytes is the scanner token limit. pg_dump output can include long
+// lines (function bodies, CHECK expressions, extensions), so we use 4 MiB
+// instead of bufio's default 64 KiB to avoid spurious ErrTooLong errors.
+const sqlMaxLineBytes = 4 * 1024 * 1024
+
 func ParseStructureSql(src []byte) ([]Field, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(src))
+	scanner.Buffer(make([]byte, 64*1024), sqlMaxLineBytes)
 	var fields []Field
 
 	inTable := false
@@ -191,10 +197,12 @@ func sqlFirstIdent(line string) string {
 	return name
 }
 
-// sqlConstraintPrefixes are keywords that start a table constraint line
-// inside a CREATE TABLE block (not a column definition).
+// sqlConstraintPrefixes are keywords that unambiguously start a table
+// constraint line inside a CREATE TABLE block. "KEY" is intentionally
+// excluded here because it is also a valid column name in some databases;
+// bare MySQL KEY index lines are handled separately in sqlIsConstraintLine.
 var sqlConstraintPrefixes = []string{
-	"PRIMARY", "UNIQUE", "KEY", "CONSTRAINT", "FOREIGN", "INDEX", "CHECK", "EXCLUDE",
+	"PRIMARY", "UNIQUE", "CONSTRAINT", "FOREIGN", "INDEX", "CHECK", "EXCLUDE",
 }
 
 // sqlIsConstraintLine reports whether an upper-cased, trimmed line is a
@@ -204,6 +212,15 @@ func sqlIsConstraintLine(upperTrimmed string) bool {
 		if strings.HasPrefix(upperTrimmed, kw) {
 			return true
 		}
+	}
+	// MySQL bare KEY index: KEY idx_name (cols) — the column list is
+	// parenthesised and follows the index name after whitespace.
+	// A column named "key" has a type next (e.g. "key varchar"), not a
+	// parenthesised list, so we check that the token after the name is '('.
+	if strings.HasPrefix(upperTrimmed, "KEY") &&
+		(len(upperTrimmed) == 3 || !sqlIsWordByte(upperTrimmed[3])) {
+		_, rest := sqlNextIdent(strings.TrimSpace(upperTrimmed[3:]))
+		return strings.HasPrefix(strings.TrimSpace(rest), "(")
 	}
 	return false
 }

--- a/internal/schema/rails_structure_test.go
+++ b/internal/schema/rails_structure_test.go
@@ -258,9 +258,9 @@ func TestSqlNextIdent(t *testing.T) {
 		{`"users" more`, "users", " more"},
 		{"`users` more", "users", " more"},
 		{"users more", "users", " more"},
-		{"users", "users", ""},          // unquoted with no separator → rest is ""
-		{`"unterminated`, "", ""},       // unterminated double-quote
-		{"`unterminated", "", ""},       // unterminated backtick
+		{"users", "users", ""},    // unquoted with no separator → rest is ""
+		{`"unterminated`, "", ""}, // unterminated double-quote
+		{"`unterminated", "", ""}, // unterminated backtick
 		{"", "", ""},
 	}
 	for _, tt := range tests {
@@ -278,11 +278,11 @@ func TestSqlExtractCreateTableName(t *testing.T) {
 		want  string
 	}{
 		{"not a create statement", ""},
-		{"CREATE TABLE ", ""},                           // empty after keyword → ident1 == ""
+		{"CREATE TABLE ", ""}, // empty after keyword → ident1 == ""
 		{`CREATE TABLE "users" (`, "users"},
 		{"CREATE TABLE public.users (", "users"},
 		{`CREATE TABLE "public"."users" (`, "users"},
-		{`CREATE TABLE public.( (`, "public"},           // dot then non-ident → fall back to ident1
+		{`CREATE TABLE public.( (`, "public"}, // dot then non-ident → fall back to ident1
 	}
 	for _, tt := range tests {
 		if got := sqlExtractCreateTableName(tt.input); got != tt.want {
@@ -297,13 +297,13 @@ func TestSqlExtractAlterAddColumn(t *testing.T) {
 		wantTable string
 		wantCol   string
 	}{
-		{"RENAME TABLE users TO new_name", "", ""},                             // no "ALTER TABLE" present
-		{"ALTER TABLE ", "", ""},                                                 // ident1 == ""
-		{`ALTER TABLE "users" RENAME TO new_users`, "", ""},                     // addIdx < 0
-		{`ALTER TABLE "users" ADDING COLUMN "bio" text`, "", ""},               // "ADD" is part of "ADDING"
+		{"RENAME TABLE users TO new_name", "", ""},               // no "ALTER TABLE" present
+		{"ALTER TABLE ", "", ""},                                 // ident1 == ""
+		{`ALTER TABLE "users" RENAME TO new_users`, "", ""},      // addIdx < 0
+		{`ALTER TABLE "users" ADDING COLUMN "bio" text`, "", ""}, // "ADD" is part of "ADDING"
 		{`ALTER TABLE "users" ADD COLUMN "bio" text`, "users", "bio"},
 		{`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "bio" text`, "users", "bio"},
-		{`ALTER TABLE public.( ADD COLUMN "email" varchar`, "public", "email"},  // schema. fallback to ident1
+		{`ALTER TABLE public.( ADD COLUMN "email" varchar`, "public", "email"}, // schema. fallback to ident1
 	}
 	for _, tt := range tests {
 		table, col := sqlExtractAlterAddColumn(tt.input)

--- a/internal/schema/rails_structure_test.go
+++ b/internal/schema/rails_structure_test.go
@@ -1,0 +1,230 @@
+package schema
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseStructureSql_PostgreSQL(t *testing.T) {
+	src := []byte(`
+SET statement_timeout = 0;
+
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    email character varying NOT NULL,
+    name character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+CREATE TABLE public.articles (
+    id bigint NOT NULL,
+    title character varying,
+    body text,
+    user_id bigint NOT NULL
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	userFields := fieldNames(fields, "User")
+	if !slices.Equal(userFields, []string{"created_at", "email", "id", "name", "updated_at"}) {
+		t.Errorf("User fields: got %v", userFields)
+	}
+	articleFields := fieldNames(fields, "Article")
+	if !slices.Equal(articleFields, []string{"body", "id", "title", "user_id"}) {
+		t.Errorf("Article fields: got %v", articleFields)
+	}
+}
+
+func TestParseStructureSql_SQLite(t *testing.T) {
+	src := []byte(`
+CREATE TABLE "users" (
+  "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "email" varchar(255) NOT NULL,
+  "name" varchar(100) DEFAULT NULL,
+  "created_at" datetime(6) NOT NULL,
+  "updated_at" datetime(6) NOT NULL
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"created_at", "email", "id", "name", "updated_at"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_MySQL(t *testing.T) {
+	src := []byte("CREATE TABLE `articles` (\n" +
+		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `title` varchar(255) DEFAULT NULL,\n" +
+		"  `body` longtext,\n" +
+		"  PRIMARY KEY (`id`),\n" +
+		"  KEY `index_articles_on_title` (`title`)\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n")
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "Article")
+	if !slices.Equal(got, []string{"body", "id", "title"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_ConstraintsSkipped(t *testing.T) {
+	src := []byte(`
+CREATE TABLE "articles" (
+  "id" bigint NOT NULL,
+  "title" character varying,
+  PRIMARY KEY ("id"),
+  UNIQUE ("title"),
+  CONSTRAINT "articles_title_check" CHECK (char_length(title) > 0),
+  FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "Article")
+	if !slices.Equal(got, []string{"id", "title"}) {
+		t.Errorf("constraints should be skipped, got %v", got)
+	}
+}
+
+func TestParseStructureSql_AlterTableAddColumn(t *testing.T) {
+	src := []byte(`
+CREATE TABLE "users" (
+  "id" bigint NOT NULL,
+  "email" character varying NOT NULL
+);
+
+ALTER TABLE "users" ADD COLUMN "bio" text;
+ALTER TABLE ONLY "users" ADD COLUMN "avatar_url" character varying;
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"avatar_url", "bio", "email", "id"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_AlterTableAddColumn_SchemaPrefix(t *testing.T) {
+	src := []byte(`
+ALTER TABLE public.users ADD COLUMN bio text;
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"bio"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_AlterTableAddConstraint_Skipped(t *testing.T) {
+	// ADD CONSTRAINT should not be confused with ADD COLUMN.
+	src := []byte(`
+CREATE TABLE "users" (
+  "id" bigint NOT NULL,
+  "email" character varying NOT NULL
+);
+
+ALTER TABLE ONLY "users" ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"email", "id"}) {
+		t.Errorf("constraint ALTER should be skipped, got %v", got)
+	}
+}
+
+func TestParseStructureSql_SchemaRbWins(t *testing.T) {
+	// Verifies the detection order at the parser level (both parse correctly).
+	// Integration-level ordering is covered in check_test.go.
+	rbSrc := []byte(`
+ActiveRecord::Schema.define do
+  create_table "users", force: :cascade do |t|
+    t.string "schema_rb_field"
+  end
+end
+`)
+	sqlSrc := []byte(`
+CREATE TABLE "users" (
+  "id" bigint NOT NULL,
+  "structure_sql_field" character varying
+);
+`)
+	rbFields, err := ParseSchemaRb(rbSrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlFields, err := ParseStructureSql(sqlSrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fieldNames(rbFields, "User")[0] != "schema_rb_field" {
+		t.Errorf("schema.rb parsed incorrectly: %v", rbFields)
+	}
+	if fieldNames(sqlFields, "User")[0] != "id" {
+		t.Errorf("structure.sql parsed incorrectly: %v", sqlFields)
+	}
+}
+
+func TestParseStructureSql_IfNotExists(t *testing.T) {
+	src := []byte(`
+CREATE TABLE IF NOT EXISTS "users" (
+  "id" bigint NOT NULL,
+  "email" character varying NOT NULL
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"email", "id"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_Empty(t *testing.T) {
+	fields, err := ParseStructureSql([]byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("want no fields from empty input, got %v", fields)
+	}
+}
+
+func TestParseStructureSql_UnquotedNames(t *testing.T) {
+	src := []byte(`
+CREATE TABLE users (
+    id bigint NOT NULL,
+    email varchar(255) NOT NULL
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"email", "id"}) {
+		t.Errorf("got %v", got)
+	}
+}

--- a/internal/schema/rails_structure_test.go
+++ b/internal/schema/rails_structure_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -225,6 +226,40 @@ CREATE TABLE users (
 	}
 	got := fieldNames(fields, "User")
 	if !slices.Equal(got, []string{"email", "id"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseStructureSql_ColumnNamedKey(t *testing.T) {
+	// A column literally named "key" must not be mistaken for a MySQL KEY index line.
+	src := []byte(`
+CREATE TABLE "api_tokens" (
+  "id" bigint NOT NULL,
+  "key" character varying NOT NULL,
+  "value" text
+);
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "ApiToken")
+	if !slices.Equal(got, []string{"id", "key", "value"}) {
+		t.Errorf("column named 'key' should not be skipped, got %v", got)
+	}
+}
+
+func TestParseStructureSql_LongLine(t *testing.T) {
+	// Lines longer than bufio's default 64 KiB (e.g. long CHECK expressions)
+	// must not cause an ErrTooLong error.
+	longComment := strings.Repeat("x", 128*1024)
+	src := []byte("-- " + longComment + "\nCREATE TABLE \"users\" (\n  \"id\" bigint NOT NULL\n);\n")
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error for long line: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"id"}) {
 		t.Errorf("got %v", got)
 	}
 }

--- a/internal/schema/rails_structure_test.go
+++ b/internal/schema/rails_structure_test.go
@@ -228,3 +228,88 @@ CREATE TABLE users (
 		t.Errorf("got %v", got)
 	}
 }
+
+func TestParseStructureSql_AlterAddColumn_IfNotExists(t *testing.T) {
+	src := []byte(`
+CREATE TABLE "users" (
+  "id" bigint NOT NULL
+);
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "bio" text;
+`)
+	fields, err := ParseStructureSql(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := fieldNames(fields, "User")
+	if !slices.Equal(got, []string{"bio", "id"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+// Tests for internal helper functions (package-level access).
+
+func TestSqlNextIdent(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantIdent string
+		wantRest  string
+	}{
+		{`"users" more`, "users", " more"},
+		{"`users` more", "users", " more"},
+		{"users more", "users", " more"},
+		{"users", "users", ""},          // unquoted with no separator → rest is ""
+		{`"unterminated`, "", ""},       // unterminated double-quote
+		{"`unterminated", "", ""},       // unterminated backtick
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		ident, rest := sqlNextIdent(tt.input)
+		if ident != tt.wantIdent || rest != tt.wantRest {
+			t.Errorf("sqlNextIdent(%q) = (%q, %q), want (%q, %q)",
+				tt.input, ident, rest, tt.wantIdent, tt.wantRest)
+		}
+	}
+}
+
+func TestSqlExtractCreateTableName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"not a create statement", ""},
+		{"CREATE TABLE ", ""},                           // empty after keyword → ident1 == ""
+		{`CREATE TABLE "users" (`, "users"},
+		{"CREATE TABLE public.users (", "users"},
+		{`CREATE TABLE "public"."users" (`, "users"},
+		{`CREATE TABLE public.( (`, "public"},           // dot then non-ident → fall back to ident1
+	}
+	for _, tt := range tests {
+		if got := sqlExtractCreateTableName(tt.input); got != tt.want {
+			t.Errorf("sqlExtractCreateTableName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSqlExtractAlterAddColumn(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantTable string
+		wantCol   string
+	}{
+		{"RENAME TABLE users TO new_name", "", ""},                             // no "ALTER TABLE" present
+		{"ALTER TABLE ", "", ""},                                                 // ident1 == ""
+		{`ALTER TABLE "users" RENAME TO new_users`, "", ""},                     // addIdx < 0
+		{`ALTER TABLE "users" ADDING COLUMN "bio" text`, "", ""},               // "ADD" is part of "ADDING"
+		{`ALTER TABLE "users" ADD COLUMN "bio" text`, "users", "bio"},
+		{`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "bio" text`, "users", "bio"},
+		{`ALTER TABLE public.( ADD COLUMN "email" varchar`, "public", "email"},  // schema. fallback to ident1
+	}
+	for _, tt := range tests {
+		table, col := sqlExtractAlterAddColumn(tt.input)
+		if table != tt.wantTable || col != tt.wantCol {
+			t.Errorf("sqlExtractAlterAddColumn(%q) = (%q, %q), want (%q, %q)",
+				tt.input, table, col, tt.wantTable, tt.wantCol)
+		}
+	}
+}


### PR DESCRIPTION
Closes #97

## Summary

- Add `ParseStructureSql` in `internal/schema/rails_structure.go` to parse `db/structure.sql` files generated by Rails when `config.active_record.schema_format = :sql`
- Handles `CREATE TABLE` blocks and `ALTER TABLE … ADD COLUMN` statements
- Supports PostgreSQL (double-quoted), MySQL (backtick-quoted), and unquoted identifier styles, plus optional schema prefixes (`public.users`)
- Update `runCheckRails` detection order: `schema.rb` → `structure.sql` → `db/migrate/`
- Update `docs/content/docs/usage/rails.md` to document the three-source detection order

## Test plan

- [ ] `TestParseStructureSql_PostgreSQL` — CREATE TABLE with schema prefix and multiple tables
- [ ] `TestParseStructureSql_SQLite` — double-quoted identifiers
- [ ] `TestParseStructureSql_MySQL` — backtick-quoted identifiers, KEY constraint skipped
- [ ] `TestParseStructureSql_ConstraintsSkipped` — PRIMARY KEY, UNIQUE, CONSTRAINT, FOREIGN KEY all skipped
- [ ] `TestParseStructureSql_AlterTableAddColumn` — ADD COLUMN and ADD COLUMN with ONLY
- [ ] `TestParseStructureSql_AlterTableAddConstraint_Skipped` — ADD CONSTRAINT not treated as ADD COLUMN
- [ ] `TestParseStructureSql_IfNotExists` — CREATE TABLE IF NOT EXISTS
- [ ] `TestRunCheck_Rails_StructureSql_RefsFound` — integration: no schema.rb, structure.sql used
- [ ] `TestRunCheck_Rails_StructureSql_SchemaRbWins` — integration: schema.rb takes priority when both present
- [ ] `TestRunCheck_Rails_StructureSql_FallsBackToMigrations` — integration: no structure.sql, falls through to migrations
- [ ] `TestRunCheck_Rails_StructureSql_ReadError` — unreadable structure.sql returns error
- [ ] `TestRunCheck_Rails_StructureSql_ParseError` — injected parse error returns error