### PR TITLE
feat(rails): detect symbol/hash-based attribute access

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -17,7 +17,7 @@ All three mean the reference was detected. The label indicates how it was found 
 |--------|-----------|------------|
 | ✅ | AST attribute node (`article.title`) | Highest — unambiguous |
 | ✅ `[string]` | Literal string or symbol passed to a known ORM method (`.where(title: value)`, `.pluck(:title)`) | High — method is known to accept field names |
-| ✅ `[symbol]` | Symbol literal in general Ruby accessor (`article[:title]`, `send(:title)`) | Medium — not Rails-specific; verify manually |
+| ✅ `[symbol]` | Symbol literal in general Ruby accessor (`article[:title]`, `article.send(:title)`) | Medium — not Rails-specific; verify manually |
 | ✅ `[getattr]` | Literal string in `getattr(obj, "field")` or `attrgetter("field")` | Lower — built-in, not model-specific; verify manually |
 | ✅ `[sql ref]` | Word-boundary substring match inside a raw SQL string (`.where("title = ?", value)`) | Lower — verify manually, false positives possible |
 

--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -17,6 +17,7 @@ All three mean the reference was detected. The label indicates how it was found 
 |--------|-----------|------------|
 | ✅ | AST attribute node (`article.title`) | Highest — unambiguous |
 | ✅ `[string]` | Literal string or symbol passed to a known ORM method (`.where(title: value)`, `.pluck(:title)`) | High — method is known to accept field names |
+| ✅ `[symbol]` | Symbol literal in general Ruby accessor (`article[:title]`, `send(:title)`) | Medium — not Rails-specific; verify manually |
 | ✅ `[getattr]` | Literal string in `getattr(obj, "field")` or `attrgetter("field")` | Lower — built-in, not model-specific; verify manually |
 | ✅ `[sql ref]` | Word-boundary substring match inside a raw SQL string (`.where("title = ?", value)`) | Lower — verify manually, false positives possible |
 
@@ -291,6 +292,22 @@ The field name appears as a string element inside the `update_fields` list passe
 </details>
 
 <details>
+<summary>Hash / symbol access</summary>
+
+The field name appears as a symbol literal. These are general Ruby patterns — not Rails-specific — so the `[symbol]` label signals lower confidence than `[string]` hits from known ORM methods. Variable symbols (`article.send(field_var)`) remain out of scope. `send` and `public_send` require a receiver.
+
+| Pattern | Example | Result |
+|---------|---------|--------|
+| Symbol subscript | `article[:title]` | ✅ `[symbol]` |
+| `read_attribute` | `article.read_attribute(:title)` | ✅ `[symbol]` |
+| `write_attribute` | `article.write_attribute(:title, value)` | ✅ `[symbol]` |
+| `send` | `article.send(:title)` | ✅ `[symbol]` |
+| `public_send` | `article.public_send(:title)` | ✅ `[symbol]` |
+| Variable symbol | `article.send(field_var)` | ❌ out of scope — symbol not statically visible |
+
+</details>
+
+<details>
 <summary>Model declarations (partial)</summary>
 
 The `scope` declaration itself is not matched, but calls inside the scope body are scanned normally.
@@ -302,19 +319,6 @@ The `scope` declaration itself is not matched, but calls inside the scope body a
 </details>
 
 ### Not detected
-
-<details>
-<summary>Hash / symbol access</summary>
-
-| Pattern | Example | Result |
-|---------|---------|--------|
-| Symbol subscript | `article[:title]` | ❌ |
-| `read_attribute` | `article.read_attribute(:title)` | ❌ |
-| `write_attribute` | `article.write_attribute(:title, value)` | ❌ |
-| `send` | `article.send(:title)` | ❌ |
-| `public_send` | `article.public_send(:title)` | ❌ |
-
-</details>
 
 <details>
 <summary>Model declarations</summary>

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -28,6 +28,13 @@ var rubySymbolArgMethods = map[string]bool{
 	"minimum":       true, "maximum": true, "sum": true,
 }
 
+// rubySymbolFirstArgMethods are methods whose first positional symbol argument
+// is the field name. Matched with a [symbol] label.
+var rubySymbolFirstArgMethods = map[string]bool{
+	"read_attribute": true, "write_attribute": true,
+	"send": true, "public_send": true,
+}
+
 // rubyHashKeyArgMethods are ActiveRecord methods that accept field names as
 // hash keys. "not" is included but validated against a where receiver at call
 // time to avoid matching unrelated DSL methods.
@@ -168,6 +175,23 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 		}
 		methodName := method.Content(src)
 
+		if rubySymbolFirstArgMethods[methodName] {
+			receiver := node.ChildByFieldName("receiver")
+			if receiver == nil {
+				break
+			}
+			for i := 0; i < int(args.ChildCount()); i++ {
+				child := args.Child(i)
+				if child.Type() == "simple_symbol" {
+					if rubySymbolName(child, src) == fieldName {
+						addRubySymbolRef(child, lines, file, refs)
+					}
+					break
+				}
+			}
+			break
+		}
+
 		if rubySqlMethods[methodName] {
 			for i := 0; i < int(args.ChildCount()); i++ {
 				child := args.Child(i)
@@ -230,6 +254,7 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 
 	case "element_reference":
 		// Article.arel_table[:field] or arel_table[:field] (implicit self)
+		// Also: article[:field] — symbol subscript attribute access.
 		if node.ChildCount() >= 3 {
 			receiver := node.Child(0)
 			if receiver != nil {
@@ -237,11 +262,13 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 					receiver.ChildByFieldName("method") != nil &&
 					receiver.ChildByFieldName("method").Content(src) == "arel_table") ||
 					(receiver.Type() == "identifier" && receiver.Content(src) == "arel_table")
-				if isArelTable {
-					for i := 1; i < int(node.ChildCount()); i++ {
-						sym := node.Child(i)
-						if sym.Type() == "simple_symbol" && rubySymbolName(sym, src) == fieldName {
+				for i := 1; i < int(node.ChildCount()); i++ {
+					sym := node.Child(i)
+					if sym.Type() == "simple_symbol" && rubySymbolName(sym, src) == fieldName {
+						if isArelTable {
 							addRubyStringRef(node, lines, file, refs)
+						} else {
+							addRubySymbolRef(node, lines, file, refs)
 						}
 					}
 				}
@@ -325,6 +352,16 @@ func addRubyStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Re
 		File: file,
 		Line: row + 1,
 		Text: "[string] " + strings.TrimSpace(lineAt(lines, row)),
+	})
+}
+
+// addRubySymbolRef appends a [symbol]-labeled Reference at the node's source row.
+func addRubySymbolRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
+	row := int(node.StartPoint().Row)
+	*refs = append(*refs, Reference{
+		File: file,
+		Line: row + 1,
+		Text: "[symbol] " + strings.TrimSpace(lineAt(lines, row)),
 	})
 }
 

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -182,12 +182,15 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 			}
 			for i := 0; i < int(args.ChildCount()); i++ {
 				child := args.Child(i)
-				if child.Type() == "simple_symbol" {
-					if rubySymbolName(child, src) == fieldName {
-						addRubySymbolRef(child, lines, file, refs)
-					}
-					break
+				t := child.Type()
+				if t == "(" || t == ")" || t == "," {
+					continue
 				}
+				// Only match when the first positional argument is a symbol literal.
+				if t == "simple_symbol" && rubySymbolName(child, src) == fieldName {
+					addRubySymbolRef(child, lines, file, refs)
+				}
+				break
 			}
 			break
 		}

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2849,3 +2849,16 @@ func TestScanRubyStringRefs_Send_NoReceiver_NotDetected(t *testing.T) {
 		t.Errorf("want 0 refs for receiverless send, got %d: %v", len(refs), refs)
 	}
 }
+
+func TestScanRubyStringRefs_Send_SymbolNotFirst_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.send("other", :title)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs when symbol is not first arg, got %d: %v", len(refs), refs)
+	}
+}

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2728,3 +2728,124 @@ func TestScanRubyStringRefs_Heredoc_Execute(t *testing.T) {
 		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
 	}
 }
+
+// --- symbol access tests ---
+
+func TestScanRubyStringRefs_SymbolSubscript(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article[:title]`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[symbol] ") {
+		t.Errorf("want [symbol] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_SymbolSubscript_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article[:slug]`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_ReadAttribute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article.read_attribute(:title)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[symbol] ") {
+		t.Errorf("want [symbol] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_WriteAttribute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.write_attribute(:title, "new")`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[symbol] ") {
+		t.Errorf("want [symbol] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_Send(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article.send(:title)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[symbol] ") {
+		t.Errorf("want [symbol] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_PublicSend(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article.public_send(:title)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[symbol] ") {
+		t.Errorf("want [symbol] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_Send_VariableArg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = article.send(field_name)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for variable arg, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_Send_NoReceiver_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `x = send(:title)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for receiverless send, got %d: %v", len(refs), refs)
+	}
+}

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -9,6 +9,11 @@ References found for Article.title
   references.rb:15          article.title
   references.rb:16          article&.title
   references.rb:19          article.title
+  references.rb:22          [symbol] x = article[:title]                                   # symbol subscript
+  references.rb:23          [symbol] x = article.read_attribute(:title)                    # read_attribute
+  references.rb:24          [symbol] article.write_attribute(:title, value)                # write_attribute
+  references.rb:25          [symbol] x = article.send(:title)                              # send with symbol
+  references.rb:26          [symbol] x = article.public_send(:title)                       # public_send
   references.rb:29          [string] a = Article.new(title: value)                         # new
   references.rb:30          [string] a = Article.create(title: value)                      # create
   references.rb:31          [string] a = Article.find_or_create_by(title: value)           # find_or_create_by


### PR DESCRIPTION
## Summary

Adds `[symbol]`-labeled detection for five Rails attribute access patterns:

- `article[:title]` — symbol subscript
- `article.read_attribute(:title)`
- `article.write_attribute(:title, value)`
- `article.send(:title)`
- `article.public_send(:title)`

`send` and `public_send` require a receiver to avoid false positives on standalone calls. Variable-symbol forms (`send(field_var)`) remain out of scope.

The `[symbol]` label signals lower confidence than `[string]` hits (these are general Ruby patterns, not Rails-specific).

## Changes

- `internal/refs/rails.go`: new `rubySymbolFirstArgMethods` map + handling in `walkNodeRubyStringRefsInner`; `element_reference` case extended for non-arel_table receivers; `addRubySymbolRef` helper added
- `internal/refs/refs_test.go`: 8 new unit tests
- `test_patterns/rails/golden_title.txt`: 5 new expected lines
- `docs/content/docs/detection-patterns.md`: Hash/symbol access moved to Detected; `[symbol]` row added to output labels table

## Test plan

- [x] Unit tests for all 5 patterns + no-receiver and variable-arg non-detection
- [x] Pattern battery `TestE2E_PatternBattery_Rails` passes
- [x] Coverage 100%

Closes #119