### PR TITLE
feat(rails): detect average, count, and calculate aggregation methods

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -264,6 +264,9 @@ The field name appears as a string element inside the `update_fields` list passe
 | `minimum` | `.minimum(:title)` | ✅ `[string]` |
 | `maximum` | `.maximum(:title)` | ✅ `[string]` |
 | `sum` | `.sum(:title)` | ✅ `[string]` |
+| `average` | `.average(:price)` | ✅ `[string]` |
+| `count` (column form) | `.count(:status)` | ✅ `[string]` |
+| `calculate` | `.calculate(:sum, :price)` | ✅ `[string]` (second arg) |
 
 </details>
 

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -25,7 +25,8 @@ var rubySymbolArgMethods = map[string]bool{
 	"select": true, "order": true, "pluck": true,
 	"pick": true, "group": true, "reorder": true,
 	"update_column": true,
-	"minimum":       true, "maximum": true, "sum": true,
+	"minimum": true, "maximum": true, "sum": true,
+	"average": true, "count": true,
 }
 
 // rubyHashKeyArgMethods are ActiveRecord methods that accept field names as
@@ -177,6 +178,26 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 						addRubySqlRef(child, lines, file, refs)
 					}
 					break
+				}
+			}
+			break
+		}
+
+		if methodName == "calculate" {
+			// calculate(:operation, :column) — second positional symbol/string arg is the field.
+			pos := 0
+			for i := 0; i < int(args.ChildCount()); i++ {
+				child := args.Child(i)
+				if child.Type() == "simple_symbol" || child.Type() == "string" {
+					if pos == 1 {
+						if child.Type() == "simple_symbol" && rubySymbolName(child, src) == fieldName {
+							addRubyStringRef(child, lines, file, refs)
+						} else if child.Type() == "string" && rubyStringContent(child, src) == fieldName {
+							addRubyStringRef(child, lines, file, refs)
+						}
+						break
+					}
+					pos++
 				}
 			}
 			break

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -25,7 +25,7 @@ var rubySymbolArgMethods = map[string]bool{
 	"select": true, "order": true, "pluck": true,
 	"pick": true, "group": true, "reorder": true,
 	"update_column": true,
-	"minimum": true, "maximum": true, "sum": true,
+	"minimum":       true, "maximum": true, "sum": true,
 	"average": true, "count": true,
 }
 

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2611,6 +2611,91 @@ func TestScanRubyStringRefs_Sum(t *testing.T) {
 	}
 }
 
+func TestScanRubyStringRefs_Average(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.average(:price)`)
+	refs, _, err := ScanRubyStringRefs(dir, "price")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.average(:price)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Count_ColumnForm(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.count(:status)`)
+	refs, _, err := ScanRubyStringRefs(dir, "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.count(:status)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Count_NoArg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.count`)
+	refs, _, err := ScanRubyStringRefs(dir, "count")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("count with no args should not produce refs, got: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Calculate_Symbol(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.calculate(:sum, :price)`)
+	refs, _, err := ScanRubyStringRefs(dir, "price")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] Article.calculate(:sum, :price)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Calculate_String(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.calculate(:sum, "price")`)
+	refs, _, err := ScanRubyStringRefs(dir, "price")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != `[string] Article.calculate(:sum, "price")` {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Calculate_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.calculate(:sum, :amount)`)
+	refs, _, err := ScanRubyStringRefs(dir, "price")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("wrong field should not produce refs, got: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Calculate_OperationNotField(t *testing.T) {
+	// :sum is the operation (first arg), not the field — must not be detected as "sum" field.
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.calculate(:sum, :price)`)
+	refs, _, err := ScanRubyStringRefs(dir, "sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("operation symbol should not be detected as field ref, got: %v", refs)
+	}
+}
+
 // ── Rails raw SQL reference tests ────────────────────────────────────────────
 
 func TestScanRubyStringRefs_FindBySql_StringArg(t *testing.T) {

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -36,10 +36,14 @@ References found for Article.title
   references.rb:59          [string] Article.minimum(:title)                               # minimum
   references.rb:60          [string] Article.maximum(:title)                               # maximum
   references.rb:61          [string] Article.sum(:title)                                   # sum
-  references.rb:64          [string] t = Article.arel_table[:title]                        # table subscript
-  references.rb:65          [string] Article.arel_table[:title].eq(value)                  # arel condition
-  references.rb:66          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
-  references.rb:82          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
-  references.rb:83          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
-  references.rb:84          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
-  references.rb:85          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc
+  references.rb:62          [string] Article.average(:title)                               # average
+  references.rb:63          [string] Article.count(:title)                                 # count (column form)
+  references.rb:64          [string] Article.calculate(:sum, :title)                       # calculate symbol
+  references.rb:65          [string] Article.calculate(:sum, "title")                      # calculate string
+  references.rb:68          [string] t = Article.arel_table[:title]                        # table subscript
+  references.rb:69          [string] Article.arel_table[:title].eq(value)                  # arel condition
+  references.rb:70          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
+  references.rb:86          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  references.rb:87          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  references.rb:88          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  references.rb:89          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -59,6 +59,10 @@ if false
   Article.minimum(:title)                               # minimum
   Article.maximum(:title)                               # maximum
   Article.sum(:title)                                   # sum
+  Article.average(:title)                               # average
+  Article.count(:title)                                 # count (column form)
+  Article.calculate(:sum, :title)                       # calculate symbol
+  Article.calculate(:sum, "title")                      # calculate string
 
   # ── Arel ──────────────────────────────────────────────────────────────────────
   t = Article.arel_table[:title]                        # table subscript


### PR DESCRIPTION
Closes #127

## Summary

- Add `average` and `count` (column form) to `rubySymbolArgMethods` so their first positional symbol/string arg is detected as a field reference with `[string]` label
- Add special handling for `calculate(:operation, :column)` — the **second** positional arg is the field name; the first (operation) is skipped
- Update test pattern battery (`test_patterns/rails/references.rb`) and golden file with 4 new patterns
- Update `docs/content/docs/detection-patterns.md` aggregation table

## New patterns detected

| Method | Example | Label |
|--------|---------|-------|
| `average` | `Article.average(:price)` | `[string]` |
| `count` (column form) | `Article.count(:status)` | `[string]` |
| `calculate` | `Article.calculate(:sum, :price)` | `[string]` |
| `calculate` (string) | `Article.calculate(:sum, "price")` | `[string]` |

`count` without a column argument (e.g. `Article.count`) produces no refs — correct behaviour since there is no field reference.

## Test plan

- [x] `TestScanRubyStringRefs_Average` — symbol arg detected
- [x] `TestScanRubyStringRefs_Count_ColumnForm` — symbol arg detected
- [x] `TestScanRubyStringRefs_Count_NoArg_NotDetected` — no false positive for bare `count`
- [x] `TestScanRubyStringRefs_Calculate_Symbol` — second symbol arg detected
- [x] `TestScanRubyStringRefs_Calculate_String` — second string arg detected
- [x] `TestScanRubyStringRefs_Calculate_WrongField_NotDetected` — no false positive for different field
- [x] `TestScanRubyStringRefs_Calculate_OperationNotField` — first arg (operation) not treated as field
- [x] `TestE2E_PatternBattery_Rails` — golden file updated and passes
- [x] 100% test coverage maintained