### PR TITLE
feat(rails): detect Rails 6+ bulk write operations

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -222,6 +222,23 @@ The field name appears as a string element inside the `update_fields` list passe
 </details>
 
 <details>
+<summary>ActiveRecord — bulk write (Rails 6+)</summary>
+
+The field name appears as a hash key. The first positional argument may be a single hash (for `insert`, `insert!`, `upsert`) or an array of hashes (for the `_all` variants). Bang variants are treated identically to their non-bang counterparts.
+
+| Method | Example | Result |
+|--------|---------|--------|
+| `insert` | `Article.insert({title: "a"})` | ✅ `[string]` |
+| `insert!` | `Article.insert!({title: "a"})` | ✅ `[string]` |
+| `insert_all` | `Article.insert_all([{title: "a"}, ...])` | ✅ `[string]` |
+| `insert_all!` | `Article.insert_all!([{title: "a"}])` | ✅ `[string]` |
+| `upsert` | `Article.upsert({title: "a"})` | ✅ `[string]` |
+| `upsert_all` | `Article.upsert_all([{title: "a"}, ...])` | ✅ `[string]` |
+| Variable argument | `Article.insert_all(records)` | ❌ out of scope — hash keys not statically visible |
+
+</details>
+
+<details>
 <summary>ActiveRecord — instance update</summary>
 
 | Method | Example | Result |

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -53,6 +53,14 @@ var rubyHashKeyArgMethods = map[string]bool{
 	"find_by": true, "exists?": true,
 }
 
+// rubyBulkWriteMethods are Rails 6+ bulk write methods. Their first positional
+// argument is either a hash ({col: val}) or an array of hashes ([{col: val}]).
+var rubyBulkWriteMethods = map[string]bool{
+	"insert": true, "insert!": true,
+	"insert_all": true, "insert_all!": true,
+	"upsert": true, "upsert_all": true,
+}
+
 // rubySqlMethods are Ruby/ActiveRecord methods whose first positional string
 // argument is raw SQL.
 var rubySqlMethods = map[string]bool{
@@ -197,6 +205,27 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 				// Only match when the first positional argument is a symbol literal.
 				if t == "simple_symbol" && rubySymbolName(child, src) == fieldName {
 					addRubySymbolRef(child, lines, file, refs)
+				}
+				break
+			}
+			break
+		}
+
+		if rubyBulkWriteMethods[methodName] {
+			for i := 0; i < int(args.ChildCount()); i++ {
+				child := args.Child(i)
+				t := child.Type()
+				if t == "(" || t == ")" || t == "," {
+					continue
+				}
+				if t == "hash" {
+					scanRubyHashPairs(child, src, lines, fieldName, file, refs)
+				} else if t == "array" {
+					for j := 0; j < int(child.ChildCount()); j++ {
+						if elem := child.Child(j); elem.Type() == "hash" {
+							scanRubyHashPairs(elem, src, lines, fieldName, file, refs)
+						}
+					}
 				}
 				break
 			}
@@ -393,6 +422,21 @@ func isWordChar(c byte) bool {
 }
 
 // addRubyStringRef appends a [string]-labeled Reference at the node's source row.
+// scanRubyHashPairs scans pair children of a hash node and emits a [string]
+// reference for each hash_key_symbol key that matches fieldName.
+func scanRubyHashPairs(hash *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
+	for i := 0; i < int(hash.ChildCount()); i++ {
+		pair := hash.Child(i)
+		if pair.Type() != "pair" {
+			continue
+		}
+		key := pair.ChildByFieldName("key")
+		if key != nil && key.Type() == "hash_key_symbol" && key.Content(src) == fieldName {
+			addRubyStringRef(key, lines, file, refs)
+		}
+	}
+}
+
 func addRubyStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
 	row := int(node.StartPoint().Row)
 	*refs = append(*refs, Reference{

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -214,13 +214,12 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 		if rubyBulkWriteMethods[methodName] {
 			for i := 0; i < int(args.ChildCount()); i++ {
 				child := args.Child(i)
-				t := child.Type()
-				if t == "(" || t == ")" || t == "," {
+				switch child.Type() {
+				case "(", ")", ",":
 					continue
-				}
-				if t == "hash" {
+				case "hash":
 					scanRubyHashPairs(child, src, lines, fieldName, file, refs)
-				} else if t == "array" {
+				case "array":
 					for j := 0; j < int(child.ChildCount()); j++ {
 						if elem := child.Child(j); elem.Type() == "hash" {
 							scanRubyHashPairs(elem, src, lines, fieldName, file, refs)

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -420,7 +420,6 @@ func isWordChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
 }
 
-// addRubyStringRef appends a [string]-labeled Reference at the node's source row.
 // scanRubyHashPairs scans pair children of a hash node and emits a [string]
 // reference for each hash_key_symbol key that matches fieldName.
 func scanRubyHashPairs(hash *sitter.Node, src []byte, lines [][]byte, fieldName, file string, refs *[]Reference) {
@@ -436,6 +435,7 @@ func scanRubyHashPairs(hash *sitter.Node, src []byte, lines [][]byte, fieldName,
 	}
 }
 
+// addRubyStringRef appends a [string]-labeled Reference at the node's source row.
 func addRubyStringRef(node *sitter.Node, lines [][]byte, file string, refs *[]Reference) {
 	row := int(node.StartPoint().Row)
 	*refs = append(*refs, Reference{

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -3057,3 +3057,127 @@ func TestScanRubyStringRefs_Send_SymbolNotFirst_NotDetected(t *testing.T) {
 		t.Errorf("want 0 refs when symbol is not first arg, got %d: %v", len(refs), refs)
 	}
 }
+
+// --- Rails 6+ bulk write tests ---
+
+func TestScanRubyStringRefs_Insert_SingleHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.insert({title: "a", slug: "b"})`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+	if !strings.HasPrefix(refs[0].Text, "[string] ") {
+		t.Errorf("want [string] prefix, got %q", refs[0].Text)
+	}
+}
+
+func TestScanRubyStringRefs_InsertBang_SingleHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.insert!({title: "a"})`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_InsertAll_ArrayOfHashes(t *testing.T) {
+	dir := t.TempDir()
+	// Single line: dedupeByLine collapses both hashes to one ref.
+	writeFile(t, dir, "app.rb", `Article.insert_all([{title: "a"}, {title: "b"}])`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (deduped by line), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_InsertAll_MultiLine(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", "Article.insert_all([\n  {title: \"a\"},\n  {title: \"b\"},\n])")
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs for multi-line array, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_InsertAllBang_ArrayOfHashes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.insert_all!([{title: "a"}])`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_Upsert_SingleHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.upsert({title: "a", slug: "b"})`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_UpsertAll_ArrayOfHashes(t *testing.T) {
+	dir := t.TempDir()
+	// Single line: dedupeByLine collapses both hashes to one ref.
+	writeFile(t, dir, "app.rb", `Article.upsert_all([{title: "a"}, {title: "b"}])`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref (deduped by line), got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_InsertAll_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.insert_all([{slug: "a"}])`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for wrong field, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestScanRubyStringRefs_InsertAll_NonHashArg_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `Article.insert_all(records)`)
+
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("want 0 refs for variable arg, got %d: %v", len(refs), refs)
+	}
+}

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -18,42 +18,48 @@ References found for Article.title
   references.rb:30          [string] a = Article.create(title: value)                      # create
   references.rb:31          [string] a = Article.find_or_create_by(title: value)           # find_or_create_by
   references.rb:32          [string] a = Article.find_or_initialize_by(title: value)       # find_or_initialize_by
-  references.rb:35          [string] article.update(title: value)                          # update
-  references.rb:36          [string] article.assign_attributes(title: value)               # assign_attributes
-  references.rb:37          [string] article.update_column(:title, value)                  # update_column symbol
-  references.rb:38          [string] article.update_columns(title: value)                  # update_columns hash
-  references.rb:41          [string] Article.where(title: value)                           # where hash
-  references.rb:42          [sql ref] Article.where("title = ?", value)                     # where string
-  references.rb:43          [string] Article.where.not(title: value)                       # where.not
-  references.rb:44          [string] Article.find_by(title: value)                         # find_by
-  references.rb:45          [string] Article.exists?(title: value)                         # exists?
-  references.rb:46          [string] Article.order(:title)                                 # order symbol
-  references.rb:47          [string] Article.order(title: :desc)                           # order hash
-  references.rb:48          [sql ref] Article.order("title ASC")                            # order string
-  references.rb:49          [string] Article.pluck(:title)                                 # pluck symbol
-  references.rb:50          [string] Article.pluck("title")                                # pluck string
-  references.rb:51          [string] Article.select(:title)                                # select symbol
-  references.rb:52          [sql ref] Article.select("title, slug")                         # select string
-  references.rb:53          [string] Article.group(:title)                                 # group symbol
-  references.rb:54          [string] Article.pick(:title)                                  # pick
-  references.rb:55          [string] Article.reorder(:title)                               # reorder
-  references.rb:56          [string] Article.update_all(title: value)                      # update_all
-  references.rb:59          [string] Article.minimum(:title)                               # minimum
-  references.rb:60          [string] Article.maximum(:title)                               # maximum
-  references.rb:61          [string] Article.sum(:title)                                   # sum
-  references.rb:62          [string] Article.average(:title)                               # average
-  references.rb:63          [string] Article.count(:title)                                 # count (column form)
-  references.rb:64          [string] Article.calculate(:sum, :title)                       # calculate symbol
-  references.rb:65          [string] Article.calculate(:sum, "title")                      # calculate string
-  references.rb:68          [string] t = Article.arel_table[:title]                        # table subscript
-  references.rb:69          [string] Article.arel_table[:title].eq(value)                  # arel condition
-  references.rb:70          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
-  references.rb:78          [string] article.slice(:title, :slug)                          # slice symbols
-  references.rb:79          [string] article.as_json(only: [:title])                       # as_json only:
-  references.rb:80          [string] article.as_json(except: [:title])                     # as_json except:
-  references.rb:81          [string] article.to_json(only: [:title])                       # to_json only:
-  references.rb:82          [string] article.to_xml(only: [:title])                        # to_xml only:
-  references.rb:91          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
-  references.rb:92          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
-  references.rb:93          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
-  references.rb:94          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc
+  references.rb:35          [string] Article.insert({title: "a", slug: "b"})               # insert single hash
+  references.rb:36          [string] Article.insert!({title: "a"})                         # insert! single hash
+  references.rb:37          [string] Article.insert_all([{title: "a"}, {title: "b"}])      # insert_all array
+  references.rb:38          [string] Article.insert_all!([{title: "a"}])                   # insert_all! array
+  references.rb:39          [string] Article.upsert({title: "a", slug: "b"})               # upsert single hash
+  references.rb:40          [string] Article.upsert_all([{title: "a"}, {title: "b"}])      # upsert_all array
+  references.rb:43          [string] article.update(title: value)                          # update
+  references.rb:44          [string] article.assign_attributes(title: value)               # assign_attributes
+  references.rb:45          [string] article.update_column(:title, value)                  # update_column symbol
+  references.rb:46          [string] article.update_columns(title: value)                  # update_columns hash
+  references.rb:49          [string] Article.where(title: value)                           # where hash
+  references.rb:50          [sql ref] Article.where("title = ?", value)                     # where string
+  references.rb:51          [string] Article.where.not(title: value)                       # where.not
+  references.rb:52          [string] Article.find_by(title: value)                         # find_by
+  references.rb:53          [string] Article.exists?(title: value)                         # exists?
+  references.rb:54          [string] Article.order(:title)                                 # order symbol
+  references.rb:55          [string] Article.order(title: :desc)                           # order hash
+  references.rb:56          [sql ref] Article.order("title ASC")                            # order string
+  references.rb:57          [string] Article.pluck(:title)                                 # pluck symbol
+  references.rb:58          [string] Article.pluck("title")                                # pluck string
+  references.rb:59          [string] Article.select(:title)                                # select symbol
+  references.rb:60          [sql ref] Article.select("title, slug")                         # select string
+  references.rb:61          [string] Article.group(:title)                                 # group symbol
+  references.rb:62          [string] Article.pick(:title)                                  # pick
+  references.rb:63          [string] Article.reorder(:title)                               # reorder
+  references.rb:64          [string] Article.update_all(title: value)                      # update_all
+  references.rb:67          [string] Article.minimum(:title)                               # minimum
+  references.rb:68          [string] Article.maximum(:title)                               # maximum
+  references.rb:69          [string] Article.sum(:title)                                   # sum
+  references.rb:70          [string] Article.average(:title)                               # average
+  references.rb:71          [string] Article.count(:title)                                 # count (column form)
+  references.rb:72          [string] Article.calculate(:sum, :title)                       # calculate symbol
+  references.rb:73          [string] Article.calculate(:sum, "title")                      # calculate string
+  references.rb:76          [string] t = Article.arel_table[:title]                        # table subscript
+  references.rb:77          [string] Article.arel_table[:title].eq(value)                  # arel condition
+  references.rb:78          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
+  references.rb:86          [string] article.slice(:title, :slug)                          # slice symbols
+  references.rb:87          [string] article.as_json(only: [:title])                       # as_json only:
+  references.rb:88          [string] article.as_json(except: [:title])                     # as_json except:
+  references.rb:89          [string] article.to_json(only: [:title])                       # to_json only:
+  references.rb:90          [string] article.to_xml(only: [:title])                        # to_xml only:
+  references.rb:99          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  references.rb:100         [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  references.rb:101         [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  references.rb:102         [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -31,6 +31,14 @@ if false
   a = Article.find_or_create_by(title: value)           # find_or_create_by
   a = Article.find_or_initialize_by(title: value)       # find_or_initialize_by
 
+  # ── ActiveRecord — bulk write (Rails 6+) ─────────────────────────────────────
+  Article.insert({title: "a", slug: "b"})               # insert single hash
+  Article.insert!({title: "a"})                         # insert! single hash
+  Article.insert_all([{title: "a"}, {title: "b"}])      # insert_all array
+  Article.insert_all!([{title: "a"}])                   # insert_all! array
+  Article.upsert({title: "a", slug: "b"})               # upsert single hash
+  Article.upsert_all([{title: "a"}, {title: "b"}])      # upsert_all array
+
   # ── ActiveRecord — instance update ───────────────────────────────────────────
   article.update(title: value)                          # update
   article.assign_attributes(title: value)               # assign_attributes


### PR DESCRIPTION
## Summary

Adds `[string]`-labeled detection for the Rails 6+ bulk write family:

| Method | Argument form |
|--------|--------------|
| `insert`, `insert!` | single hash `{col: val}` |
| `insert_all`, `insert_all!` | array of hashes `[{col: val}, ...]` |
| `upsert` | single hash `{col: val}` |
| `upsert_all` | array of hashes `[{col: val}, ...]` |

Hash keys in the first positional argument are matched as field references. Variable arguments (`insert_all(records)`) remain out of scope.

## Implementation

- `rubyBulkWriteMethods` map for all 6 methods
- `scanRubyHashPairs` helper to scan hash `pair` children
- Handler in `walkNodeRubyStringRefsInner`: finds first positional arg, dispatches on `hash` or `array` type
- `switch` used per staticcheck QF1003

## Test plan

- [x] Unit tests: all 6 methods, multi-line array (2 refs on different lines), wrong field, variable arg
- [x] Pattern battery `TestE2E_PatternBattery_Rails` passes
- [x] Coverage 100%

Closes #128