### PR TITLE
feat(rails): detect slice, as_json, to_json, to_xml selective field patterns

### DIFF
--- a/docs/content/docs/detection-patterns.md
+++ b/docs/content/docs/detection-patterns.md
@@ -338,8 +338,14 @@ The `scope` declaration itself is not matched, but calls inside the scope body a
 
 | Pattern | Example | Result |
 |---------|---------|--------|
+| `slice` | `article.slice(:title, :slug)` | ✅ `[string]` |
+| `as_json(only:)` | `article.as_json(only: [:title])` | ✅ `[string]` |
+| `as_json(except:)` | `article.as_json(except: [:created_at])` | ✅ `[string]` |
+| `to_json(only:)` | `article.to_json(only: [:title])` | ✅ `[string]` |
+| `to_xml(only:)` | `article.to_xml(only: [:title])` | ✅ `[string]` |
 | Strong params `permit` | `params.require(:article).permit(:title, :slug)` | ❌ |
 | ActiveModel Serializer `attributes` | `attributes :title, :slug` | ❌ |
+| `as_json(only:)` with dynamic array | `article.as_json(only: fields)` | ❌ |
 
 </details>
 

--- a/internal/refs/rails.go
+++ b/internal/refs/rails.go
@@ -27,6 +27,13 @@ var rubySymbolArgMethods = map[string]bool{
 	"update_column": true,
 	"minimum":       true, "maximum": true, "sum": true,
 	"average": true, "count": true,
+	"slice": true,
+}
+
+// rubyOnlyExceptMethods are ActiveRecord/Rails serialization methods that accept
+// an only: or except: keyword argument whose value is an array of field symbols/strings.
+var rubyOnlyExceptMethods = map[string]bool{
+	"as_json": true, "to_json": true, "to_xml": true,
 }
 
 // rubySymbolFirstArgMethods are methods whose first positional symbol argument
@@ -255,6 +262,22 @@ func walkNodeRubyStringRefsInner(node *sitter.Node, src []byte, lines [][]byte, 
 					key := child.ChildByFieldName("key")
 					if key != nil && key.Type() == "hash_key_symbol" && key.Content(src) == fieldName {
 						addRubyStringRef(key, lines, file, refs)
+					}
+				}
+				if rubyOnlyExceptMethods[methodName] {
+					key := child.ChildByFieldName("key")
+					val := child.ChildByFieldName("value")
+					if key != nil && key.Type() == "hash_key_symbol" &&
+						(key.Content(src) == "only" || key.Content(src) == "except") &&
+						val != nil && val.Type() == "array" {
+						for j := 0; j < int(val.ChildCount()); j++ {
+							elem := val.Child(j)
+							if elem.Type() == "simple_symbol" && rubySymbolName(elem, src) == fieldName {
+								addRubyStringRef(elem, lines, file, refs)
+							} else if elem.Type() == "string" && rubyStringContent(elem, src) == fieldName {
+								addRubyStringRef(elem, lines, file, refs)
+							}
+						}
 					}
 				}
 			case "string":

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -2696,6 +2696,116 @@ func TestScanRubyStringRefs_Calculate_OperationNotField(t *testing.T) {
 	}
 }
 
+// ── Rails serialization / slice / as_json tests (issue #129) ─────────────────
+
+func TestScanRubyStringRefs_Slice_Symbol(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.slice(:title, :slug)`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] article.slice(:title, :slug)" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_Slice_String(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.slice("title", "slug")`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != `[string] article.slice("title", "slug")` {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AsJson_Only_Symbol(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.as_json(only: [:title, :slug])`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] article.as_json(only: [:title, :slug])" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AsJson_Only_String(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.as_json(only: ["title"])`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != `[string] article.as_json(only: ["title"])` {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AsJson_Except(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.as_json(except: [:created_at])`)
+	refs, _, err := ScanRubyStringRefs(dir, "created_at")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] article.as_json(except: [:created_at])" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_ToJson_Only(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.to_json(only: [:title])`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] article.to_json(only: [:title])" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_ToXml_Only(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.to_xml(only: [:title])`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].Text != "[string] article.to_xml(only: [:title])" {
+		t.Errorf("unexpected refs: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AsJson_WrongField_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.as_json(only: [:slug])`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("wrong field should not produce refs, got: %v", refs)
+	}
+}
+
+func TestScanRubyStringRefs_AsJson_DynamicArray_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "app.rb", `article.as_json(only: fields)`)
+	refs, _, err := ScanRubyStringRefs(dir, "title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("dynamic array should not produce refs, got: %v", refs)
+	}
+}
+
 // ── Rails raw SQL reference tests ────────────────────────────────────────────
 
 func TestScanRubyStringRefs_FindBySql_StringArg(t *testing.T) {

--- a/test_patterns/rails/golden_title.txt
+++ b/test_patterns/rails/golden_title.txt
@@ -48,7 +48,12 @@ References found for Article.title
   references.rb:68          [string] t = Article.arel_table[:title]                        # table subscript
   references.rb:69          [string] Article.arel_table[:title].eq(value)                  # arel condition
   references.rb:70          [string] scope :titled, ->(v) { where(arel_table[:title].eq(v)) }  # implicit self
-  references.rb:86          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
-  references.rb:87          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
-  references.rb:88          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
-  references.rb:89          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc
+  references.rb:78          [string] article.slice(:title, :slug)                          # slice symbols
+  references.rb:79          [string] article.as_json(only: [:title])                       # as_json only:
+  references.rb:80          [string] article.as_json(except: [:title])                     # as_json except:
+  references.rb:81          [string] article.to_json(only: [:title])                       # to_json only:
+  references.rb:82          [string] article.to_xml(only: [:title])                        # to_xml only:
+  references.rb:91          [sql ref] Article.find_by_sql("SELECT title FROM articles WHERE title = ?", value)    # find_by_sql string
+  references.rb:92          [sql ref] connection.execute("UPDATE articles SET title = ?", value)                  # execute string
+  references.rb:93          [sql ref] connection.select_all("SELECT title, slug FROM articles")                   # select_all string
+  references.rb:94          [sql ref] Article.find_by_sql(<<~SQL)                                                  # find_by_sql heredoc

--- a/test_patterns/rails/references.rb
+++ b/test_patterns/rails/references.rb
@@ -75,6 +75,11 @@ if false
   # ── Serialization / presentation ─────────────────────────────────────────────
   params.require(:article).permit(:title, :slug)        # strong params permit
   # AMS attributes: see app/serializers/article_serializer.rb
+  article.slice(:title, :slug)                          # slice symbols
+  article.as_json(only: [:title])                       # as_json only:
+  article.as_json(except: [:title])                     # as_json except:
+  article.to_json(only: [:title])                       # to_json only:
+  article.to_xml(only: [:title])                        # to_xml only:
 
   # ── Dynamic / metaprogramming ─────────────────────────────────────────────────
   article.respond_to?(:title)                           # respond_to?


### PR DESCRIPTION
Closes #129

## Summary

- Add `slice` to `rubySymbolArgMethods` — positional symbol/string args detected as `[string]` refs (same logic as `pluck`)
- Add `rubyOnlyExceptMethods` `{as_json, to_json, to_xml}` with new pair-handler: when `only:` or `except:` key has a literal array value, each symbol/string element is emitted as a `[string]` ref
- Dynamic arrays (variable, splat) are not matched — out of scope per issue

## New patterns detected

| Method | Example | Label |
|--------|---------|-------|
| `slice` | `article.slice(:title, :slug)` | `[string]` |
| `as_json(only:)` | `article.as_json(only: [:title])` | `[string]` |
| `as_json(except:)` | `article.as_json(except: [:created_at])` | `[string]` |
| `to_json(only:)` | `article.to_json(only: [:title])` | `[string]` |
| `to_xml(only:)` | `article.to_xml(only: [:title])` | `[string]` |

## Test plan

- [x] `TestScanRubyStringRefs_Slice_Symbol` — positional symbol arg
- [x] `TestScanRubyStringRefs_Slice_String` — positional string arg
- [x] `TestScanRubyStringRefs_AsJson_Only_Symbol` — symbol in `only:` array
- [x] `TestScanRubyStringRefs_AsJson_Only_String` — string in `only:` array
- [x] `TestScanRubyStringRefs_AsJson_Except` — `except:` key also detected
- [x] `TestScanRubyStringRefs_ToJson_Only`
- [x] `TestScanRubyStringRefs_ToXml_Only`
- [x] `TestScanRubyStringRefs_AsJson_WrongField_NotDetected` — no false positive for different field
- [x] `TestScanRubyStringRefs_AsJson_DynamicArray_NotDetected` — variable array not matched
- [x] `TestE2E_PatternBattery_Rails` — golden file updated and passes
- [x] 100% test coverage maintained