### PR TITLE
docs: add use cases page

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -30,5 +30,6 @@ No references found for User.email
 
 → [Getting started]({{< relref "docs/getting-started" >}}) — installation and first run  
 → [Usage]({{< relref "docs/usage/_index" >}}) — flags reference and ORM-specific behavior  
+→ [Use cases]({{< relref "docs/use-cases" >}}) — schema cleanup, CI integration, audits, and more  
 → [How it works]({{< relref "docs/how-it-works" >}}) — AST parsing and schema extraction  
 → [Detection patterns]({{< relref "docs/detection-patterns" >}}) — what is and isn't detected  

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -7,6 +7,7 @@ type: docs
 
 - [Getting started]({{< relref "getting-started" >}}) — installation and first run
 - [Usage]({{< relref "usage/_index" >}}) — flags reference and ORM-specific behavior
+- [Use cases]({{< relref "use-cases" >}}) — schema cleanup, CI integration, audits, and more
 - [How it works]({{< relref "how-it-works" >}}) — AST parsing and schema extraction
 - [Detection patterns]({{< relref "detection-patterns" >}}) — what is and isn't detected
 - [Limitations]({{< relref "limitations" >}}) — what static analysis can't cover

--- a/docs/content/docs/use-cases.md
+++ b/docs/content/docs/use-cases.md
@@ -44,11 +44,20 @@ This is a precondition check, not a guess. If colref returns references, the con
 If a pull request migration drops or renames a column, run colref automatically and fail the build (or post a comment) if references remain.
 
 ```sh
-# detect dropped columns from migration diff
-DROPPED=$(git diff origin/main -- "db/migrate/*.rb" | grep -oP "remove_column :\w+, :\K\w+")
+# detect dropped columns from migration diff (Rails example)
+DROPPED=$(git diff origin/main -- "db/migrate/*.rb" \
+  | grep "remove_column" \
+  | grep -oE ":[a-z_]+" \
+  | tail -1 \
+  | tr -d ':')
 
 for field in $DROPPED; do
-  colref check --orm rails --model YourModel --field "$field" ./ && echo "SAFE" || exit 1
+  output=$(colref check --orm rails --model YourModel --field "$field")
+  echo "$output"
+  if echo "$output" | grep -q "^References found"; then
+    echo "colref: references to $field still exist — remove them before dropping the column" >&2
+    exit 1
+  fi
 done
 ```
 
@@ -60,7 +69,7 @@ The output direction matters here (see [Output direction](#output-direction) bel
 
 ### Sensitive column access map
 
-Where is `email` read? Where is `password_digest` written?
+Where is `email` referenced? Where does `password` appear in code?
 
 ```sh
 colref check --orm django --model User --field email
@@ -78,7 +87,7 @@ Combine colref with a search for serialization methods to check whether a sensit
 colref check --orm rails --model User --field ssn
 
 # check for serializer declarations
-grep -rn "as_json\|to_json\|attributes.*ssn" app/
+grep -rn -E "as_json|to_json|attributes.*ssn" app/
 ```
 
 If colref finds accesses and a serializer declaration includes the field name, investigate whether that output is exposed externally.
@@ -93,7 +102,7 @@ New to a codebase and want to understand how a column is used?
 colref check --orm django --model Article --field status
 ```
 
-Returns every place `status` is read or written, with file and line number. Faster than searching, and without the noise.
+Returns every place `status` is referenced, with file and line number. Faster than searching, and without the noise.
 
 ### Blast radius estimation
 

--- a/docs/content/docs/use-cases.md
+++ b/docs/content/docs/use-cases.md
@@ -45,14 +45,18 @@ If a pull request migration drops or renames a column, run colref automatically 
 
 ```sh
 # detect dropped columns from migration diff (Rails example)
+# adjust the model name to match your application's naming convention
+# note: remove_column :table, :column[, :type] — tail -2 | head -1 isolates the column symbol
 DROPPED=$(git diff origin/main -- "db/migrate/*.rb" \
   | grep "remove_column" \
   | grep -oE ":[a-z_]+" \
-  | tail -1 \
+  | tail -2 | head -1 \
   | tr -d ':')
 
+MODEL=User  # replace with the model that owns the dropped column
+
 for field in $DROPPED; do
-  output=$(colref check --orm rails --model YourModel --field "$field")
+  output=$(colref check --orm rails --model "$MODEL" --field "$field")
   echo "$output"
   if echo "$output" | grep -q "^References found"; then
     echo "colref: references to $field still exist — remove them before dropping the column" >&2
@@ -69,11 +73,11 @@ The output direction matters here (see [Output direction](#output-direction) bel
 
 ### Sensitive column access map
 
-Where is `email` referenced? Where does `password` appear in code?
+Where is `email` referenced? Where does `ssn` appear in code?
 
 ```sh
 colref check --orm django --model User --field email
-colref check --orm django --model User --field password
+colref check --orm django --model User --field ssn
 ```
 
 The output shows every place in the codebase that touches these fields. This doesn't replace a proper data flow audit, but it surfaces access points quickly — useful when preparing for a privacy review or mapping data flows for compliance documentation.
@@ -87,7 +91,7 @@ Combine colref with a search for serialization methods to check whether a sensit
 colref check --orm rails --model User --field ssn
 
 # check for serializer declarations
-grep -rn -E "as_json|to_json|attributes.*ssn" app/
+grep -rnE "as_json|to_json|attributes.*ssn" app/
 ```
 
 If colref finds accesses and a serializer declaration includes the field name, investigate whether that output is exposed externally.

--- a/docs/content/docs/use-cases.md
+++ b/docs/content/docs/use-cases.md
@@ -1,0 +1,123 @@
+---
+title: Use cases
+weight: 25
+---
+
+# Use cases
+
+colref started as a deletion check — "is it safe to remove this column?" — but the underlying operation (find every reference to a specific field) is useful in more situations. This page documents the ones that come up regularly.
+
+## Schema cleanup
+
+### Dead column detection
+
+Instead of starting from a specific deletion candidate, work backwards from the schema. Take a column from your migration history you don't recognize, run colref, and see what comes back.
+
+```sh
+colref check --orm django --model Article --field legacy_content
+```
+
+Zero results: it goes on the deletion candidate list. You're not verifying a decision — you're generating the list to decide about. This is faster than schema archaeology, and it turns "I think this might be unused" into "not referenced in Python code."
+
+### Rename impact mapping
+
+Before renaming a column, enumerate every location that needs updating:
+
+```sh
+colref check --orm rails --model User --field email_address
+```
+
+The output becomes the codemod target list. You're not asking "can I rename this?" — you're answering "what changes when I do?"
+
+### Expand-contract verification
+
+Zero-downtime column removal follows a two-phase pattern: first add the new column and migrate data (expand), then drop the old column once all code is updated (contract). Before the contract phase, confirm the old column is no longer referenced:
+
+```sh
+colref check --orm django --model Order --field legacy_status
+```
+
+This is a precondition check, not a guess. If colref returns references, the contract migration is not safe to run yet.
+
+## CI integration
+
+If a pull request migration drops or renames a column, run colref automatically and fail the build (or post a comment) if references remain.
+
+```sh
+# detect dropped columns from migration diff
+DROPPED=$(git diff origin/main -- "db/migrate/*.rb" | grep -oP "remove_column :\w+, :\K\w+")
+
+for field in $DROPPED; do
+  colref check --orm rails --model YourModel --field "$field" ./ && echo "SAFE" || exit 1
+done
+```
+
+"Can we delete this?" stops being a judgment call and becomes a gate. This works well as one rule inside a PR review bot: detect the migration, run the check, block if references are found.
+
+The output direction matters here (see [Output direction](#output-direction) below): blocking on "references found" is reliable. That evidence is real.
+
+## Audit and governance
+
+### Sensitive column access map
+
+Where is `email` read? Where is `password_digest` written?
+
+```sh
+colref check --orm django --model User --field email
+colref check --orm django --model User --field password
+```
+
+The output shows every place in the codebase that touches these fields. This doesn't replace a proper data flow audit, but it surfaces access points quickly — useful when preparing for a privacy review or mapping data flows for compliance documentation.
+
+### API exposure check (Rails)
+
+Combine colref with a search for serialization methods to check whether a sensitive column reaches the JSON response:
+
+```sh
+# find where the column is accessed
+colref check --orm rails --model User --field ssn
+
+# check for serializer declarations
+grep -rn "as_json\|to_json\|attributes.*ssn" app/
+```
+
+If colref finds accesses and a serializer declaration includes the field name, investigate whether that output is exposed externally.
+
+## Code understanding
+
+### Reference navigation
+
+New to a codebase and want to understand how a column is used?
+
+```sh
+colref check --orm django --model Article --field status
+```
+
+Returns every place `status` is read or written, with file and line number. Faster than searching, and without the noise.
+
+### Blast radius estimation
+
+Before touching a column, estimate the scope of changes:
+
+```sh
+colref check --orm rails --model Post --field published_at
+```
+
+A column with 40 references across 15 files carries more change risk than one with 3 references in a single file. The reference count is a signal, not a guarantee — but it tells you whether to expect a small patch or a broad refactor.
+
+## Output direction
+
+Before deciding how much to automate any of these, understand how colref fails. It can miss references (dynamic access, templates, admin class attributes — see [Limitations]({{< relref "limitations" >}})), but it does not fabricate them.
+
+This creates an asymmetry:
+
+| Result | Interpretation | Reliable for automation? |
+|--------|---------------|--------------------------|
+| References found | The field is definitely used | Yes — block deletion, CI fail |
+| No references found | Not found by the scanner | No — candidate only, requires human verification |
+
+**"References found" is a hard signal.** You can use it to block a CI pipeline with confidence.
+
+**"No references found" is a lower bound.** Dynamic access, templates, and other unscanned patterns may still reference the column. Treat zero results as a starting point for human review, not as proof the column is unused.
+
+This asymmetry shapes what you should automate. Blocking on evidence is safe. Triggering deletion on absence of evidence is not.


### PR DESCRIPTION
## Summary

- Add `docs/content/docs/use-cases.md` (weight: 25, between Usage and How it works)
- Add link to the new page from `docs/_index.md` and `content/_index.md`

## What's in the page

- **Schema cleanup** — dead column detection, rename impact mapping, expand-contract verification
- **CI integration** — auto-run colref when a migration drops/renames a column, block if references remain
- **Audit and governance** — sensitive column access map, API exposure check (Rails `as_json`)
- **Code understanding** — reference navigation for new joiners, blast radius estimation
- **Output direction** — the found/not-found asymmetry: "references found" is a hard signal safe for automation; "no references found" is a lower bound that requires human verification