### PR TITLE
docs: adopt hint shortcodes for safety caveats

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -129,6 +129,10 @@ References found for Account.memorial
   app/services/delete_account_service.rb:231                @account.memorial
 ```
 
+{{< hint warning >}}
+**No references found ≠ safe to delete.** Always verify manually — dynamic references such as `getattr(obj, var)` are out of scope.
+{{< /hint >}}
+
 ## Next steps
 
 - [Usage]({{< relref "usage/_index" >}}) — all flags, ORM-specific behavior

--- a/docs/content/docs/limitations.md
+++ b/docs/content/docs/limitations.md
@@ -7,7 +7,10 @@ weight: 50
 
 colref uses static AST analysis and cannot detect every reference pattern. References where the field name is constructed at runtime (e.g. `getattr(obj, field_name)`) are out of scope by design.
 
-**If colref reports no references, treat it as "none found by the scanner" — not as a guarantee the column is unused.**
+{{< hint warning >}}
+**No references found ≠ safe to delete.**
+colref reports what static analysis can see. Dynamic references such as `getattr(obj, var)` are out of scope by design — treat zero results as a starting point for human review, not as proof the column is unused.
+{{< /hint >}}
 
 ## Django
 

--- a/docs/content/docs/use-cases.md
+++ b/docs/content/docs/use-cases.md
@@ -129,8 +129,12 @@ This creates an asymmetry:
 | References found | The field is definitely used | Yes — block deletion, CI fail |
 | No references found | Not found by the scanner | No — candidate only, requires human verification |
 
+{{< hint note >}}
 **"References found" is a hard signal.** You can use it to block a CI pipeline with confidence.
+{{< /hint >}}
 
+{{< hint warning >}}
 **"No references found" is a lower bound.** Dynamic access, templates, and other unscanned patterns may still reference the column. Treat zero results as a starting point for human review, not as proof the column is unused.
+{{< /hint >}}
 
 This asymmetry shapes what you should automate. Blocking on evidence is safe. Triggering deletion on absence of evidence is not.


### PR DESCRIPTION
## Summary

- Converts plain bold-text warnings about "no references found ≠ safe to delete" into `{{< hint >}}` callouts in `getting-started.md`, `limitations.md`, and `use-cases.md`
- Safety caveats are now visually distinct colored boxes instead of inline bold text
- Uses `warning` for "no references found" caveats and `note` for "references found is a hard signal"

## Test plan

- [ ] Run `hugo server` from `docs/` and verify hint boxes render correctly on each page
- [ ] Check light mode and dark mode both display hint colors properly

Closes #192