### PR TITLE
docs: restructure docs — separate installation page and remove duplicate examples

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -28,7 +28,8 @@ No references found for User.email
   Verify manually before deleting.
 ```
 
-→ [Getting started]({{< relref "docs/getting-started" >}}) — installation and first run  
+→ [Installation]({{< relref "docs/installation" >}}) — pip, gem, brew, curl, or manual download  
+→ [Getting started]({{< relref "docs/getting-started" >}}) — first run examples  
 → [Usage]({{< relref "docs/usage/_index" >}}) — flags reference and ORM-specific behavior  
 → [Use cases]({{< relref "docs/use-cases" >}}) — schema cleanup, CI integration, audits, and more  
 → [How it works]({{< relref "docs/how-it-works" >}}) — AST parsing and schema extraction  

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -5,7 +5,8 @@ type: docs
 
 # Documentation
 
-- [Getting started]({{< relref "getting-started" >}}) — installation and first run
+- [Installation]({{< relref "installation" >}}) — install methods (pip, gem, brew, curl, manual)
+- [Getting started]({{< relref "getting-started" >}}) — first run examples
 - [Usage]({{< relref "usage/_index" >}}) — flags reference and ORM-specific behavior
 - [Use cases]({{< relref "use-cases" >}}) — schema cleanup, CI integration, audits, and more
 - [How it works]({{< relref "how-it-works" >}}) — AST parsing and schema extraction

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -5,76 +5,7 @@ weight: 10
 
 # Getting started
 
-## Installation
-
-| OS | x86_64 (Intel/AMD) | arm64 |
-|---|---|---|
-| macOS | ✓ | ✓ (Apple Silicon) |
-| Linux | ✓ | ✓ |
-| Windows | ✓ | — |
-
-### pip / pipx (Python users)
-
-If you are working on a Django or Python project, install via pipx or pip. No Go installation required.
-
-```sh
-pipx install colref
-```
-
-Or with pip:
-
-```sh
-pip install colref
-```
-
-### gem (Ruby users)
-
-If you are working on a Rails or Ruby project, install via gem. No Go installation required.
-
-```sh
-gem install colref
-```
-
-### Homebrew (macOS and Linux)
-
-```sh
-brew install shinagawa-web/tap/colref
-```
-
-If you prefer to tap first:
-
-```sh
-brew tap shinagawa-web/tap
-brew install colref
-```
-
-### One-line installer (Linux and macOS)
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
-```
-
-Installs the latest release binary to `/usr/local/bin`. The script detects your OS and architecture automatically, downloads the matching tarball from the [releases page](https://github.com/shinagawa-web/colref/releases), and verifies the SHA-256 checksum before installing.
-
-To install to a different directory, set `INSTALL_DIR`:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=$HOME/.local/bin sh
-```
-
-### Manual download
-
-Pre-built binaries are also available directly on the [releases page](https://github.com/shinagawa-web/colref/releases).
-
-Verify the install:
-
-```sh
-colref --version
-```
-
-## First run
-
-### Django project
+## Django project
 
 The following example runs colref against [wagtail](https://github.com/wagtail/wagtail), a popular Django CMS.
 
@@ -101,7 +32,7 @@ References found for Page.seo_title
   wagtail/admin/tests/pages/test_create_page.py:1892   page.seo_title
 ```
 
-### Rails project
+## Rails project
 
 The following example runs colref against [mastodon](https://github.com/mastodon/mastodon).
 

--- a/docs/content/docs/installation.md
+++ b/docs/content/docs/installation.md
@@ -1,0 +1,71 @@
+---
+title: Installation
+weight: 5
+---
+
+# Installation
+
+| OS | x86_64 (Intel/AMD) | arm64 |
+|---|---|---|
+| macOS | ✓ | ✓ (Apple Silicon) |
+| Linux | ✓ | ✓ |
+| Windows | ✓ | — |
+
+## pip / pipx (Python users)
+
+If you are working on a Django or Python project, install via pipx or pip. No Go installation required.
+
+```sh
+pipx install colref
+```
+
+Or with pip:
+
+```sh
+pip install colref
+```
+
+## gem (Ruby users)
+
+If you are working on a Rails or Ruby project, install via gem. No Go installation required.
+
+```sh
+gem install colref
+```
+
+## Homebrew (macOS and Linux)
+
+```sh
+brew install shinagawa-web/tap/colref
+```
+
+If you prefer to tap first:
+
+```sh
+brew tap shinagawa-web/tap
+brew install colref
+```
+
+## One-line installer (Linux and macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | sh
+```
+
+Installs the latest release binary to `/usr/local/bin`. The script detects your OS and architecture automatically, downloads the matching tarball from the [releases page](https://github.com/shinagawa-web/colref/releases), and verifies the SHA-256 checksum before installing.
+
+To install to a different directory, set `INSTALL_DIR`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/colref/main/install.sh | INSTALL_DIR=$HOME/.local/bin sh
+```
+
+## Manual download
+
+Pre-built binaries are also available directly on the [releases page](https://github.com/shinagawa-web/colref/releases).
+
+Verify the install:
+
+```sh
+colref --version
+```

--- a/docs/content/docs/usage/django.md
+++ b/docs/content/docs/usage/django.md
@@ -5,32 +5,7 @@ weight: 21
 
 # Django
 
-## Example
-
-The following examples use [wagtail](https://github.com/wagtail/wagtail), a popular Django CMS.
-
-**No references found:**
-
-```
-$ colref check --orm django --model Page --field search_description
-Scanning 932 files...
-
-No references found for Page.search_description
-
-  Verify manually before deleting.
-```
-
-**References found:**
-
-```
-$ colref check --orm django --model Page --field seo_title
-Scanning 932 files...
-
-References found for Page.seo_title
-
-  wagtail/admin/tests/pages/test_create_page.py:1867   page.seo_title
-  wagtail/admin/tests/pages/test_create_page.py:1892   page.seo_title
-```
+See [Getting started]({{< relref "getting-started" >}}) for usage examples.
 
 ## models.py detection
 

--- a/docs/content/docs/usage/rails.md
+++ b/docs/content/docs/usage/rails.md
@@ -5,33 +5,7 @@ weight: 22
 
 # Rails
 
-## Example
-
-The following examples use [mastodon](https://github.com/mastodon/mastodon).
-
-**No references found:**
-
-```
-$ colref check --orm rails --model Account --field sensitized_at
-Scanning 1502 files...
-
-No references found for Account.sensitized_at
-
-  Verify manually before deleting.
-```
-
-**References found:**
-
-```
-$ colref check --orm rails --model Account --field memorial
-Scanning 1502 files...
-
-References found for Account.memorial
-
-  app/models/account.rb:176                                 [string] scope :without_memorial, -> { where(memorial: false) }
-  app/services/activitypub/process_account_service.rb:149   @account.memorial
-  app/services/delete_account_service.rb:231                @account.memorial
-```
+See [Getting started]({{< relref "getting-started" >}}) for usage examples.
 
 ## Schema source
 


### PR DESCRIPTION
## Summary

- Extracts installation content from `getting-started.md` into a new `installation.md` (weight 5, appears first in sidebar)
- `getting-started.md` is now first-run examples only (Django/wagtail + Rails/mastodon)
- Removes duplicate `## Example` sections from `usage/django.md` and `usage/rails.md`; adds a link to Getting started instead
- Adds Installation link to `docs/_index.md` and the top-level `_index.md` navigation

Closes #191

## Test plan

- [ ] Hugo build succeeds with no broken `relref` links
- [ ] Sidebar shows Installation above Getting started
- [ ] `usage/django.md` and `usage/rails.md` no longer contain duplicate wagtail/mastodon examples
- [ ] Top-level nav links to Installation and Getting started separately