### PR TITLE
docs: update PyPI and RubyGems homepage URL to docs site

### DIFF
--- a/scripts/build_gems.rb
+++ b/scripts/build_gems.rb
@@ -80,7 +80,7 @@ def build_gem(raw_version, platform, artifacts_dir, out_dir)
       s.platform              = platform[:gem_platform]
       s.summary               = "Check whether a database column is still referenced in your codebase before you delete it"
       s.description           = s.summary
-      s.homepage              = "https://github.com/shinagawa-web/colref"
+      s.homepage              = "https://shinagawa-web.github.io/colref/"
       s.license               = "MIT"
       s.authors               = ["Kazutomo Deguchi"]
       s.bindir                = "exe"

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -78,7 +78,7 @@ def _build_wheel(
         f"Name: colref\n"
         f"Version: {version}\n"
         f"Summary: Check whether a database column is still referenced in your codebase before you delete it\n"
-        f"Home-page: https://github.com/shinagawa-web/colref\n"
+        f"Home-page: https://shinagawa-web.github.io/colref/\n"
         f"License: MIT\n"
         f"Requires-Python: >=3.8\n"
         f"Classifier: Development Status :: 4 - Beta\n"


### PR DESCRIPTION
## Summary

- `scripts/build_wheels.py`: `Home-page` → `https://shinagawa-web.github.io/colref/`
- `scripts/build_gems.rb`: `s.homepage` → `https://shinagawa-web.github.io/colref/`

The GitHub repository URL remains in place as `Project-URL: Source` in the wheel metadata.

Closes #195

## Test plan

- [ ] Next release: PyPI "Homepage" link points to the docs site
- [ ] Next release: RubyGems "Homepage" link points to the docs site