### PR TITLE
docs: add download count badges for RubyGems and PyPI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/shinagawa-web/colref.svg)](https://pkg.go.dev/github.com/shinagawa-web/colref)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Gem Version](https://badge.fury.io/rb/colref.svg)](https://rubygems.org/gems/colref)
-[![Gem Downloads](https://img.shields.io/gem/dt/colref)](https://rubygems.org/gems/colref)
+[![Gem Downloads](https://img.shields.io/gem/dt/colref.svg)](https://rubygems.org/gems/colref)
 [![PyPI version](https://badge.fury.io/py/colref.svg)](https://pypi.org/project/colref/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/colref)](https://pypi.org/project/colref/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/colref.svg)](https://pypi.org/project/colref/)
 
 Check whether a database column is still referenced in your codebase before you delete it.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/shinagawa-web/colref.svg)](https://pkg.go.dev/github.com/shinagawa-web/colref)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Gem Version](https://badge.fury.io/rb/colref.svg)](https://rubygems.org/gems/colref)
+[![Gem Downloads](https://img.shields.io/gem/dt/colref)](https://rubygems.org/gems/colref)
 [![PyPI version](https://badge.fury.io/py/colref.svg)](https://pypi.org/project/colref/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/colref)](https://pypi.org/project/colref/)
 
 Check whether a database column is still referenced in your codebase before you delete it.
 


### PR DESCRIPTION
## Summary

`badge.fury.io` (already in the README) only renders version numbers — it cannot show download counts. This adds shields.io download badges so package download stats are visible:

- **RubyGems** total downloads: `img.shields.io/gem/dt/colref`
- **PyPI** monthly downloads: `img.shields.io/pypi/dm/colref`

Both endpoints were verified to return real data (RubyGems ~2.1k total, PyPI ~1.3k/month).

## Notes

- PyPI does not expose a cumulative total, so the PyPI badge uses monthly downloads (`dm`). Only RubyGems exposes a cumulative total (`dt`).

Closes #202