### PR TITLE
docs: show the demo GIF at the top of the docs site landing page

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -8,6 +8,8 @@ bookToc: false
 
 Check whether a database column is still referenced in your codebase before you delete it.
 
+<img src="demo.gif" width="800" alt="colref finding the real references to a field that a plain text search buries in noise">
+
 ## Why
 
 You want to remove a column from a long-running system. The column looks unused, but you're not sure. A full-text search returns hits inside comments, test fixtures, and migration history — noise that makes it hard to tell whether the column is actually read or written in live code.


### PR DESCRIPTION
## Summary

Surfaces the VHS demo GIF (added in #209) at the very top of the documentation site landing page (https://shinagawa-web.github.io/colref/), right under the one-line description and before the **Why** section — so visitors see what `colref` does before reading any prose.

## Details

- Edits only `docs/content/_index.md`.
- No new asset: the GIF is already committed at `docs/static/demo.gif`, which is Hugo's `static/` dir, so it is served at `{baseURL}demo.gif`.
- References it with a relative `demo.gif` src so it resolves correctly under the `/colref/` base path.

## Verification

Built locally with Hugo 0.162.1:

- `static/demo.gif` is copied to `public/demo.gif` ✓
- The rendered `<img src="demo.gif">` appears immediately before the `Why` heading on the home page ✓
- Relative src resolves to `/colref/demo.gif` (the served location) under the configured `baseURL` ✓

Closes #212