### PR TITLE
feat: add JSON output format for check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ colref check --orm <orm> --model <Model> --field <field> [path]
 | `--orm` | ORM type: `django`, `rails` (required) |
 | `--model` | Model name to look up (required) |
 | `--field` | Field name to search for (required) |
+| `--format` | Output format: `text` (default), `json` |
 
 Example:
 
@@ -98,6 +99,27 @@ References found for Page.seo_title
   wagtail/admin/tests/pages/test_create_page.py:1867   page.seo_title
   wagtail/admin/tests/pages/test_create_page.py:1892   page.seo_title
 ```
+
+### JSON output
+
+Use `--format json` to emit a structured result you can pipe into other tools. In this mode stdout is pure JSON (no `Scanning...` preamble), so it is safe to pipe:
+
+```
+$ colref check --orm django --model Page --field seo_title --format json
+{
+  "model": "Page",
+  "field": "seo_title",
+  "orm": "django",
+  "files_scanned": 932,
+  "reference_count": 2,
+  "references": [
+    { "file": "wagtail/admin/tests/pages/test_create_page.py", "line": 1867, "text": "page.seo_title" },
+    { "file": "wagtail/admin/tests/pages/test_create_page.py", "line": 1892, "text": "page.seo_title" }
+  ]
+}
+```
+
+When nothing is found, `reference_count` is `0` and `references` is an empty array `[]`.
 
 For ORM-specific behavior and more examples, see [Django](https://shinagawa-web.github.io/colref/docs/usage/django/) and [Rails](https://shinagawa-web.github.io/colref/docs/usage/rails/).
 

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,9 +18,10 @@ import (
 )
 
 var (
-	flagModel string
-	flagField string
-	flagOrm   string
+	flagModel  string
+	flagField  string
+	flagOrm    string
+	flagFormat string
 )
 
 var checkCmd = &cobra.Command{
@@ -30,6 +33,9 @@ var checkCmd = &cobra.Command{
 		if len(args) == 1 {
 			dir = args[0]
 		}
+		if err := validateFormat(flagFormat); err != nil {
+			return err
+		}
 		return runCheck(dir, flagModel, flagField, flagOrm)
 	},
 }
@@ -38,6 +44,7 @@ func init() {
 	checkCmd.Flags().StringVar(&flagModel, "model", "", "Model name (e.g. User)")
 	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
 	checkCmd.Flags().StringVar(&flagOrm, "orm", "", "ORM type: django, rails")
+	checkCmd.Flags().StringVar(&flagFormat, "format", "text", "Output format: text, json")
 	_ = checkCmd.MarkFlagRequired("model")
 	_ = checkCmd.MarkFlagRequired("field")
 	_ = checkCmd.MarkFlagRequired("orm")
@@ -89,7 +96,7 @@ func runCheckRails(dir, modelName, fieldName string) error {
 		if err != nil {
 			return fmt.Errorf("parse %s: %w", schemaFile, err)
 		}
-		return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
+		return runCheckFields(dir, modelName, fieldName, "rails", fields, refs.ScanRuby)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", schemaFile, err)
@@ -103,7 +110,7 @@ func runCheckRails(dir, modelName, fieldName string) error {
 		if err != nil {
 			return fmt.Errorf("parse %s: %w", structureFile, err)
 		}
-		return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
+		return runCheckFields(dir, modelName, fieldName, "rails", fields, refs.ScanRuby)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", structureFile, err)
@@ -119,7 +126,7 @@ func runCheckRailsMigrations(dir, modelName, fieldName string) error {
 	if err != nil {
 		return fmt.Errorf("parse migrations from %s: %w", migrateDir, err)
 	}
-	return runCheckFields(dir, modelName, fieldName, fields, refs.ScanRuby)
+	return runCheckFields(dir, modelName, fieldName, "rails", fields, refs.ScanRuby)
 }
 
 func runCheckDjango(dir, modelName, fieldName string) error {
@@ -190,10 +197,10 @@ func runCheckDjango(dir, modelName, fieldName string) error {
 		allFields = append(allFields, pf.fields...)
 	}
 
-	return runCheckFields(dir, modelName, fieldName, allFields, refs.ScanDjango)
+	return runCheckFields(dir, modelName, fieldName, "django", allFields, refs.ScanDjango)
 }
 
-func runCheckFields(dir, modelName, fieldName string, allFields []schema.Field, scan func(string, string) ([]refs.Reference, int, error)) error {
+func runCheckFields(dir, modelName, fieldName, ormName string, allFields []schema.Field, scan func(string, string) ([]refs.Reference, int, error)) error {
 	fieldNames := fieldsForModel(allFields, modelName)
 	if len(fieldNames) == 0 {
 		known := knownModels(allFields)
@@ -208,26 +215,83 @@ func runCheckFields(dir, modelName, fieldName string, allFields []schema.Field, 
 			fieldName, modelName, strings.Join(fieldNames, ", "))
 	}
 
-	return runScan(dir, modelName, fieldName, scan)
+	return runScan(dir, modelName, fieldName, ormName, scan)
 }
 
-func runScan(dir, modelName, fieldName string, scan func(string, string) ([]refs.Reference, int, error)) error {
-	refs, count, err := scan(dir, fieldName)
+func runScan(dir, modelName, fieldName, ormName string, scan func(string, string) ([]refs.Reference, int, error)) error {
+	references, count, err := scan(dir, fieldName)
 	if err != nil {
 		return err
 	}
 
+	if flagFormat == "json" {
+		result := buildResult(modelName, fieldName, ormName, count, references)
+		return printJSON(os.Stdout, result)
+	}
+
 	fmt.Printf("Scanning %d files...\n\n", count)
 
-	if len(refs) == 0 {
+	if len(references) == 0 {
 		fmt.Printf("No references found for %s.%s\n\n", modelName, fieldName)
 		fmt.Printf("  Verify manually before deleting.\n")
 		return nil
 	}
 
 	fmt.Printf("References found for %s.%s\n\n", modelName, fieldName)
-	printRefs(refs)
+	printRefs(references)
 	return nil
+}
+
+// checkResult is the machine-readable form of a scan, emitted with --format json.
+type checkResult struct {
+	Model          string        `json:"model"`
+	Field          string        `json:"field"`
+	Orm            string        `json:"orm"`
+	FilesScanned   int           `json:"files_scanned"`
+	ReferenceCount int           `json:"reference_count"`
+	References     []checkRefOut `json:"references"`
+}
+
+type checkRefOut struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+	Text string `json:"text"`
+}
+
+// buildResult assembles the JSON result. It is pure (no I/O) so tests can assert
+// on the structure directly without capturing stdout.
+func buildResult(modelName, fieldName, ormName string, filesScanned int, references []orm.Reference) checkResult {
+	out := make([]checkRefOut, 0, len(references))
+	for _, r := range references {
+		out = append(out, checkRefOut{File: r.File, Line: r.Line, Text: r.Text})
+	}
+	return checkResult{
+		Model:          modelName,
+		Field:          fieldName,
+		Orm:            ormName,
+		FilesScanned:   filesScanned,
+		ReferenceCount: len(out),
+		References:     out,
+	}
+}
+
+func printJSON(w io.Writer, result checkResult) error {
+	enc := json.NewEncoder(w)
+	// The Text field holds source snippets (Ruby lambdas `->`, safe-nav `&.`, ERB
+	// `<%= %>`). Disable HTML escaping so those stay readable on the wire for tools
+	// consuming the JSON, rather than being emitted as > / &.
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func validateFormat(format string) error {
+	switch format {
+	case "text", "json":
+		return nil
+	default:
+		return fmt.Errorf("unknown --format %q: supported values are text, json", format)
+	}
 }
 
 func printRefs(refs []orm.Reference) {

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -279,7 +279,8 @@ func printJSON(w io.Writer, result checkResult) error {
 	enc := json.NewEncoder(w)
 	// The Text field holds source snippets (Ruby lambdas `->`, safe-nav `&.`, ERB
 	// `<%= %>`). Disable HTML escaping so those stay readable on the wire for tools
-	// consuming the JSON, rather than being emitted as > / &.
+	// consuming the JSON, rather than as the Unicode escapes `\u003c` / `\u003e` / `\u0026`
+	// that encoding/json emits for <, >, and & by default.
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -862,7 +862,7 @@ func TestPrintJSON_DoesNotHTMLEscapeSnippets(t *testing.T) {
 		t.Fatalf("printJSON: %v", err)
 	}
 	got := buf.String()
-	// If HTML escaping were on, these would appear as -> and &.title,
+	// If HTML escaping were on, these would appear as -\u003e and \u0026.title,
 	// so their verbatim presence proves SetEscapeHTML(false) took effect.
 	for _, want := range []string{"->", "&.title"} {
 		if !strings.Contains(got, want) {

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/shinagawa-web/colref/internal/orm"
 	"github.com/shinagawa-web/colref/internal/schema"
 )
 
@@ -795,5 +798,125 @@ func TestCheckCmd_RunE_NoArg(t *testing.T) {
 	})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateFormat(t *testing.T) {
+	for _, ok := range []string{"text", "json"} {
+		if err := validateFormat(ok); err != nil {
+			t.Errorf("validateFormat(%q) = %v, want nil", ok, err)
+		}
+	}
+	if err := validateFormat("xml"); err == nil {
+		t.Error("validateFormat(\"xml\") = nil, want error")
+	}
+}
+
+func TestBuildResult(t *testing.T) {
+	refs := []orm.Reference{
+		{File: "app/models/user.rb", Line: 12, Text: "validates :email"},
+		{File: "app/mailers/user_mailer.rb", Line: 8, Text: "user.email"},
+	}
+	got := buildResult("User", "email", "rails", 42, refs)
+
+	if got.Model != "User" || got.Field != "email" || got.Orm != "rails" {
+		t.Errorf("identity fields wrong: %+v", got)
+	}
+	if got.FilesScanned != 42 {
+		t.Errorf("FilesScanned = %d, want 42", got.FilesScanned)
+	}
+	if got.ReferenceCount != len(got.References) || got.ReferenceCount != 2 {
+		t.Errorf("ReferenceCount = %d, len(References) = %d, want 2", got.ReferenceCount, len(got.References))
+	}
+	if got.References[0] != (checkRefOut{File: "app/models/user.rb", Line: 12, Text: "validates :email"}) {
+		t.Errorf("References[0] = %+v", got.References[0])
+	}
+}
+
+func TestBuildResult_EmptyReferencesEncodesAsArray(t *testing.T) {
+	got := buildResult("User", "email", "django", 5, nil)
+	if got.ReferenceCount != 0 {
+		t.Errorf("ReferenceCount = %d, want 0", got.ReferenceCount)
+	}
+	if got.References == nil {
+		t.Fatal("References is nil; must be a non-nil empty slice so JSON emits [] not null")
+	}
+
+	var buf bytes.Buffer
+	if err := printJSON(&buf, got); err != nil {
+		t.Fatalf("printJSON: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"references": []`) {
+		t.Errorf("empty references did not encode as []:\n%s", buf.String())
+	}
+}
+
+func TestPrintJSON_DoesNotHTMLEscapeSnippets(t *testing.T) {
+	// Source snippets contain characters json would HTML-escape by default
+	// (< > &). They must survive verbatim so downstream tools see real code.
+	result := buildResult("Article", "title", "rails", 1, []orm.Reference{
+		{File: "app/models/article.rb", Line: 7, Text: "scope :titled, ->(t) { where(title: t) } # article&.title"},
+	})
+	var buf bytes.Buffer
+	if err := printJSON(&buf, result); err != nil {
+		t.Fatalf("printJSON: %v", err)
+	}
+	got := buf.String()
+	// If HTML escaping were on, these would appear as -> and &.title,
+	// so their verbatim presence proves SetEscapeHTML(false) took effect.
+	for _, want := range []string{"->", "&.title"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q (HTML-escaped?):\n%s", want, got)
+		}
+	}
+}
+
+func TestCheckCmd_JSONOutput(t *testing.T) {
+	dir := setupDjangoFixture(t)
+
+	// Flag vars persist across cobra Execute calls in the test binary; reset.
+	t.Cleanup(func() { flagFormat = "text" })
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"check", dir,
+		"--model", "User",
+		"--field", "email",
+		"--orm", "django",
+		"--format", "json",
+	})
+	execErr := rootCmd.Execute()
+	_ = w.Close()
+	os.Stdout = orig
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if execErr != nil {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+
+	var result checkResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if result.Model != "User" || result.Field != "email" || result.Orm != "django" {
+		t.Errorf("unexpected result identity: %+v", result)
+	}
+	if result.ReferenceCount != len(result.References) {
+		t.Errorf("ReferenceCount = %d but len(References) = %d", result.ReferenceCount, len(result.References))
+	}
+	if result.ReferenceCount == 0 {
+		t.Error("expected at least one reference for User.email")
 	}
 }

--- a/docs/content/docs/usage/_index.md
+++ b/docs/content/docs/usage/_index.md
@@ -21,6 +21,42 @@ colref check --orm <orm> --model <Model> --field <field> [path]
 | `--orm` | ORM type: `django`, `rails` (required) |
 | `--model` | Model name to look up (required) |
 | `--field` | Field name to search for (required) |
+| `--format` | Output format: `text` (default), `json` |
+
+## Output formats
+
+### `text` (default)
+
+Human-readable output, including a `Scanning N files...` progress line and an aligned list of `file:line` references.
+
+### `json`
+
+Machine-readable output for scripting and CI. stdout is pure JSON — no `Scanning...` preamble — so it can be piped straight into `jq`:
+
+```
+colref check --orm django --model User --field email --format json path/to/project
+```
+
+```json
+{
+  "model": "User",
+  "field": "email",
+  "orm": "django",
+  "files_scanned": 6,
+  "reference_count": 1,
+  "references": [
+    {
+      "file": "accounts/views.py",
+      "line": 2,
+      "text": "user.email"
+    }
+  ]
+}
+```
+
+- `references` is always an array — `[]` when nothing matches, never `null`.
+- HTML characters are **not** escaped, so source snippets stay readable on the wire — Ruby lambdas (`->`), safe navigation (`&.`), and ERB (`<%= %>`) appear verbatim rather than as `\u003e` / `\u0026`.
+- Errors (unknown model/field/orm/format) are still reported on stderr with a non-zero exit code; they are not emitted as JSON.
 
 ## ORM-specific behavior
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -206,6 +206,66 @@ func TestE2E_JSONOutput(t *testing.T) {
 		}
 		assertContains(t, out, `unknown --format "xml"`)
 	})
+
+	t.Run("Rails", func(t *testing.T) {
+		// Exercise the Rails scan path (schema.rb + ERB views) through JSON output.
+		out, err := run(t, "check", "--orm", "rails", "--model", "User", "--field", "email", "--format", "json", "fixtures/rails")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertNotContains(t, out, "Scanning")
+
+		var result struct {
+			Orm            string `json:"orm"`
+			ReferenceCount int    `json:"reference_count"`
+			References     []struct {
+				File string `json:"file"`
+			} `json:"references"`
+		}
+		if err := json.Unmarshal(out, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+		}
+		if result.Orm != "rails" {
+			t.Errorf("orm = %q, want \"rails\"", result.Orm)
+		}
+		if result.ReferenceCount != len(result.References) {
+			t.Errorf("ReferenceCount = %d, len(References) = %d", result.ReferenceCount, len(result.References))
+		}
+		// The .erb view references email and must be scanned alongside the .rb file.
+		var sawERB bool
+		for _, r := range result.References {
+			if strings.HasSuffix(r.File, ".erb") {
+				sawERB = true
+			}
+		}
+		if !sawERB {
+			t.Errorf("expected an .erb reference in JSON output\ngot:\n%s", out)
+		}
+	})
+
+	t.Run("HTMLNotEscaped", func(t *testing.T) {
+		// The Text field carries source snippets; HTML escaping is disabled so Ruby
+		// lambdas (->), safe navigation (&.), and ERB (<%= %>) stay readable rather
+		// than being emitted as > / &. The rails pattern battery contains
+		// snippets with exactly these characters.
+		out, err := run(t, "check", "--orm", "rails", "--model", "Article", "--field", "title", "--format", "json", "../test_patterns/rails")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		// Must still be valid, parseable JSON.
+		var result struct {
+			References []json.RawMessage `json:"references"`
+		}
+		if err := json.Unmarshal(out, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+		}
+		// Raw characters present, Unicode escapes absent.
+		assertContains(t, out, "->(t)")
+		assertContains(t, out, "article&.title")
+		assertNotContains(t, out, `\u003e`) // escaped '>'
+		assertNotContains(t, out, `\u0026`) // escaped '&'
+		assertNotContains(t, out, `\u003c`) // escaped '<'
+	})
 }
 
 func TestE2E_Django_ModelsPackage(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -141,6 +142,69 @@ func TestE2E_Rails(t *testing.T) {
 		}
 		assertContains(t, out, "References found for User.email")
 		assertContains(t, out, "app/user.rb")
+	})
+}
+
+func TestE2E_JSONOutput(t *testing.T) {
+	fixture := "fixtures/django"
+
+	t.Run("RefsFound", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "--format", "json", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		// stdout must be pure, parseable JSON — no "Scanning..." preamble.
+		assertNotContains(t, out, "Scanning")
+		assertNotContains(t, out, "References found")
+
+		var result struct {
+			Model          string `json:"model"`
+			Field          string `json:"field"`
+			Orm            string `json:"orm"`
+			FilesScanned   int    `json:"files_scanned"`
+			ReferenceCount int    `json:"reference_count"`
+			References     []struct {
+				File string `json:"file"`
+				Line int    `json:"line"`
+				Text string `json:"text"`
+			} `json:"references"`
+		}
+		if err := json.Unmarshal(out, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+		}
+		if result.Model != "User" || result.Field != "email" || result.Orm != "django" {
+			t.Errorf("unexpected identity fields: %+v", result)
+		}
+		if result.ReferenceCount == 0 || result.ReferenceCount != len(result.References) {
+			t.Errorf("ReferenceCount = %d, len(References) = %d", result.ReferenceCount, len(result.References))
+		}
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "name", "--format", "json", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		var result struct {
+			ReferenceCount int               `json:"reference_count"`
+			References     []json.RawMessage `json:"references"`
+		}
+		if err := json.Unmarshal(out, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+		}
+		if result.ReferenceCount != 0 {
+			t.Errorf("ReferenceCount = %d, want 0", result.ReferenceCount)
+		}
+		// references must be [] (present), not null/omitted.
+		assertContains(t, out, `"references": []`)
+	})
+
+	t.Run("InvalidFormat", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "--format", "xml", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown format")
+		}
+		assertContains(t, out, `unknown --format "xml"`)
 	})
 }
 


### PR DESCRIPTION
Closes #211

## Summary

Adds a `--format` flag (`text` | `json`, default `text`) to `colref check` so results can be piped into other tools.

```sh
colref check --orm django --model Page --field seo_title --format json
```

```json
{
  "model": "Page",
  "field": "seo_title",
  "orm": "django",
  "files_scanned": 932,
  "reference_count": 2,
  "references": [
    { "file": "wagtail/admin/tests/pages/test_create_page.py", "line": 1867, "text": "page.seo_title" }
  ]
}
```

## Details

- In JSON mode, stdout is **pure JSON** — the `Scanning N files...` line is suppressed so output stays pipeable.
- `references` is always an array: `[]` when nothing is found (never `null`), with `reference_count: 0`.
- HTML escaping is disabled on the encoder so source snippets (Ruby `->`, `&.`, ERB `<%= %>`) stay readable on the wire instead of becoming `>` / `&`.
- Unknown `--format` values are rejected up front with a clear error.
- Error paths (unknown model/field) are unchanged: they use stderr + a non-zero exit code, not a JSON error body. Consumers should check the exit code.

## Design notes

- The result builder (`buildResult`) is a pure function, so the JSON shape is unit-tested directly without capturing stdout; a separate in-process test and e2e subprocess test confirm real stdout parses as JSON.
- `orm` is passed to `runCheckFields` as a literal at each call site (the ORM-specific functions already know which ORM they are), avoiding threading it through the top-level dispatch.

## Tests

- Unit: `buildResult` fields/counts, empty-slice → `[]`, non-HTML-escaping, `validateFormat`, in-process stdout → valid JSON.
- E2E: JSON refs-found / no-refs / invalid-format cases against real fixtures.
- Full suite + `go vet` pass.

## Out of scope

- Colorized text output is tracked separately in #210.
- The Hugo docs site (`docs/`) is not updated here; JSON output is ORM-agnostic so the README is its primary home. Happy to add a docs page if preferred.