### PR TITLE
ci: replace reviewdog golangci-lint with official golangci-lint-action

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   golangci-lint:
@@ -21,9 +20,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: --config=./.golangci.yml
-          fail_level: error
-          reporter: github-pr-check
+          version: v2.12.2
+          args: --config=./.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 version: "2"
 
+linters:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+
 formatters:
   enable:
     - gofmt
   settings:
     gofmt:
       simplify: true
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck


### PR DESCRIPTION
## Summary

Replaces `reviewdog/action-golangci-lint` with the official `golangci/golangci-lint-action` in the `golangci-lint` workflow.

## Why

The reviewdog `github-pr-check` reporter creates a separate "golangci" check run via the Checks API. GitHub grouped that run under the concurrently-running `auto-label` (`pull_request_target`) check suite, so the PR checks list showed a phantom **`auto-label / golangci`** entry — even though `auto-label.yml` defines no such job — and linting appeared twice.

The official action reports findings as inline annotations on the workflow's own job, so the lint result shows up once as `golangci-lint / golangci-lint` and the phantom check disappears.

## Changes

- Action → `golangci/golangci-lint-action@v9.3.0` (SHA-pinned)
- golangci-lint version pinned to `v2.12.2` (config is `version: "2"`)
- Flags moved to the `args` input (`--config=./.golangci.yml`)
- Dropped the now-unneeded `checks: write` permission (annotations use the default token); `contents: read` only

## Verification

- YAML parses
- `golangci-lint run --config=./.golangci.yml ./...` → 0 issues locally

Closes #215