### PR TITLE
feat: add colorized terminal output for the check command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-colref
+/colref
 e2e/colref-e2e-test
 coverage/
 repos/

--- a/cmd/colref/check.go
+++ b/cmd/colref/check.go
@@ -22,6 +22,7 @@ var (
 	flagField  string
 	flagOrm    string
 	flagFormat string
+	flagColor  string
 )
 
 var checkCmd = &cobra.Command{
@@ -36,6 +37,9 @@ var checkCmd = &cobra.Command{
 		if err := validateFormat(flagFormat); err != nil {
 			return err
 		}
+		if err := validateColor(flagColor); err != nil {
+			return err
+		}
 		return runCheck(dir, flagModel, flagField, flagOrm)
 	},
 }
@@ -45,6 +49,7 @@ func init() {
 	checkCmd.Flags().StringVar(&flagField, "field", "", "Field name (e.g. email)")
 	checkCmd.Flags().StringVar(&flagOrm, "orm", "", "ORM type: django, rails")
 	checkCmd.Flags().StringVar(&flagFormat, "format", "text", "Output format: text, json")
+	checkCmd.Flags().StringVar(&flagColor, "color", "auto", "Colorize output: auto, always, never")
 	_ = checkCmd.MarkFlagRequired("model")
 	_ = checkCmd.MarkFlagRequired("field")
 	_ = checkCmd.MarkFlagRequired("orm")
@@ -229,16 +234,18 @@ func runScan(dir, modelName, fieldName, ormName string, scan func(string, string
 		return printJSON(os.Stdout, result)
 	}
 
+	pal := newPalette()
+
 	fmt.Printf("Scanning %d files...\n\n", count)
 
 	if len(references) == 0 {
-		fmt.Printf("No references found for %s.%s\n\n", modelName, fieldName)
-		fmt.Printf("  Verify manually before deleting.\n")
+		fmt.Printf("%s\n\n", pal.yellow(fmt.Sprintf("No references found for %s.%s", modelName, fieldName)))
+		fmt.Printf("  %s\n", pal.dim("Verify manually before deleting."))
 		return nil
 	}
 
-	fmt.Printf("References found for %s.%s\n\n", modelName, fieldName)
-	printRefs(references)
+	fmt.Printf("%s\n\n", pal.green(fmt.Sprintf("References found for %s.%s", modelName, fieldName)))
+	printRefs(references, pal)
 	return nil
 }
 
@@ -295,7 +302,7 @@ func validateFormat(format string) error {
 	}
 }
 
-func printRefs(refs []orm.Reference) {
+func printRefs(refs []orm.Reference, pal palette) {
 	maxWidth := 0
 	for _, r := range refs {
 		if w := len(fmt.Sprintf("%s:%d", r.File, r.Line)); w > maxWidth {
@@ -303,8 +310,13 @@ func printRefs(refs []orm.Reference) {
 		}
 	}
 	for _, r := range refs {
+		// Width and padding are computed on the plain label so color escape
+		// codes never throw off column alignment. Matched text is left
+		// uncolored so it reads naturally against the colored metadata.
 		label := fmt.Sprintf("%s:%d", r.File, r.Line)
-		fmt.Printf("  %s%s%s\n", label, strings.Repeat(" ", maxWidth-len(label)+3), r.Text)
+		pad := strings.Repeat(" ", maxWidth-len(label)+3)
+		coloredLabel := pal.path(r.File) + pal.line(fmt.Sprintf(":%d", r.Line))
+		fmt.Printf("  %s%s%s\n", coloredLabel, pad, r.Text)
 	}
 }
 

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -932,9 +932,11 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	os.Stdout = w
+	// Restore via defer so a t.Fatal (runtime.Goexit) or panic inside fn can't
+	// leave os.Stdout redirected for the rest of the suite.
+	defer func() { os.Stdout = orig }()
 	fn()
 	_ = w.Close()
-	os.Stdout = orig
 	out, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -919,4 +920,71 @@ func TestCheckCmd_JSONOutput(t *testing.T) {
 	if result.ReferenceCount == 0 {
 		t.Error("expected at least one reference for User.email")
 	}
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// it wrote.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+var ansiPattern = regexp.MustCompile("\033\\[[0-9]*m")
+
+func stripANSI(s string) string { return ansiPattern.ReplaceAllString(s, "") }
+
+func TestRunScan_ColorAlways(t *testing.T) {
+	orig := flagColor
+	flagColor = "always"
+	t.Cleanup(func() { flagColor = orig })
+
+	t.Run("RefsFound", func(t *testing.T) {
+		dir := setupDjangoFixture(t)
+		out := captureStdout(t, func() {
+			if err := runCheck(dir, "User", "email", "django"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		// Green heading, cyan path, gray line number must be present.
+		if !strings.Contains(out, ansiGreen+"References found for User.email"+ansiReset) {
+			t.Errorf("heading not green-wrapped:\n%s", out)
+		}
+		if !strings.Contains(out, ansiCyan) || !strings.Contains(out, ansiGray) {
+			t.Errorf("path/line not colored:\n%s", out)
+		}
+		// Stripping color must reproduce the plain layout, alignment intact.
+		plain := stripANSI(out)
+		if !strings.Contains(plain, "References found for User.email") ||
+			!strings.Contains(plain, "accounts/views.py:") {
+			t.Errorf("color-stripped output lost content:\n%s", plain)
+		}
+	})
+
+	t.Run("NoRefs", func(t *testing.T) {
+		dir := setupDjangoFixture(t)
+		out := captureStdout(t, func() {
+			if err := runCheck(dir, "User", "name", "django"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		if !strings.Contains(out, ansiYellow+"No references found for User.name"+ansiReset) {
+			t.Errorf("no-refs heading not yellow-wrapped:\n%s", out)
+		}
+		if !strings.Contains(out, ansiGray+"Verify manually before deleting."+ansiReset) {
+			t.Errorf("verify hint not dimmed:\n%s", out)
+		}
+	})
 }

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -777,6 +777,42 @@ func TestCheckCmd_RunE_WithArg(t *testing.T) {
 	}
 }
 
+func TestCheckCmd_RunE_InvalidFormat(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	t.Cleanup(func() { flagFormat = "text" })
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"check", dir,
+		"--model", "User",
+		"--field", "email",
+		"--orm", "django",
+		"--format", "xml",
+	})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid --format")
+	}
+}
+
+func TestCheckCmd_RunE_InvalidColor(t *testing.T) {
+	dir := setupDjangoFixture(t)
+	t.Cleanup(func() { flagColor = "auto" })
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"check", dir,
+		"--model", "User",
+		"--field", "email",
+		"--orm", "django",
+		"--color", "rainbow",
+	})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid --color")
+	}
+}
+
 func TestCheckCmd_RunE_NoArg(t *testing.T) {
 	dir := setupDjangoFixture(t)
 

--- a/cmd/colref/color.go
+++ b/cmd/colref/color.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// ANSI color codes. Kept as raw escape sequences (mirroring the palette style
+// used elsewhere in the shinagawa-web toolchain, e.g. gomarklint's
+// internal/output/text.go) to avoid pulling in a color-library dependency.
+const (
+	ansiReset  = "\033[0m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiCyan   = "\033[36m"
+	ansiGray   = "\033[90m"
+)
+
+// palette applies ANSI colors to output fragments. When disabled, every method
+// returns its input unchanged, so the plain layout stays byte-for-byte
+// identical to the pre-color output.
+type palette struct {
+	enabled bool
+}
+
+func (p palette) wrap(code, s string) string {
+	if !p.enabled {
+		return s
+	}
+	return code + s + ansiReset
+}
+
+// green emphasizes a positive heading ("References found").
+func (p palette) green(s string) string { return p.wrap(ansiGreen, s) }
+
+// yellow emphasizes a cautionary heading ("No references found").
+func (p palette) yellow(s string) string { return p.wrap(ansiYellow, s) }
+
+// path colors a file path.
+func (p palette) path(s string) string { return p.wrap(ansiCyan, s) }
+
+// line colors a ":line" suffix.
+func (p palette) line(s string) string { return p.wrap(ansiGray, s) }
+
+// dim de-emphasizes secondary text (e.g. the manual-verification hint).
+func (p palette) dim(s string) string { return p.wrap(ansiGray, s) }
+
+// resolveColor decides whether color should be emitted. It is pure so the
+// decision logic is trivially testable.
+//
+//   - "always": always on (overrides NO_COLOR and a non-TTY destination)
+//   - "never":  always off
+//   - "auto":   on only when writing to a TTY and NO_COLOR is unset/empty
+func resolveColor(mode string, isTTY, noColor bool) bool {
+	switch mode {
+	case "always":
+		return true
+	case "never":
+		return false
+	default: // "auto"
+		return isTTY && !noColor
+	}
+}
+
+// validateColor rejects unknown --color values.
+func validateColor(mode string) error {
+	switch mode {
+	case "auto", "always", "never":
+		return nil
+	default:
+		return fmt.Errorf("unknown --color %q: supported values are auto, always, never", mode)
+	}
+}
+
+// fileIsTerminal reports whether f refers to a character device (a terminal).
+func fileIsTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// newPalette builds the palette from the --color flag and stdout's capabilities,
+// honoring the NO_COLOR convention (https://no-color.org/).
+func newPalette() palette {
+	noColor := os.Getenv("NO_COLOR") != ""
+	return palette{enabled: resolveColor(flagColor, fileIsTerminal(os.Stdout), noColor)}
+}

--- a/cmd/colref/color.go
+++ b/cmd/colref/color.go
@@ -72,7 +72,15 @@ func validateColor(mode string) error {
 	}
 }
 
-// fileIsTerminal reports whether f refers to a character device (a terminal).
+// fileIsTerminal reports whether f refers to a character device, used as a
+// dependency-free proxy for "is a terminal".
+//
+// Deliberate tradeoff: dummy character devices such as /dev/null also read as
+// terminals here, so `--color=auto` would emit ANSI codes when stdout is
+// redirected to one. That is harmless — such output is discarded — and the
+// cases that matter are handled correctly: regular files and pipes are not
+// character devices, so color is disabled for `> file` and `| cmd`. A precise
+// TTY check would need golang.org/x/term; we avoid that dependency here.
 func fileIsTerminal(f *os.File) bool {
 	info, err := f.Stat()
 	if err != nil {

--- a/cmd/colref/color_test.go
+++ b/cmd/colref/color_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveColor(t *testing.T) {
+	cases := []struct {
+		mode    string
+		isTTY   bool
+		noColor bool
+		want    bool
+	}{
+		{"always", false, true, true}, // always overrides non-TTY and NO_COLOR
+		{"always", true, false, true},
+		{"never", true, false, false}, // never overrides a TTY
+		{"never", false, true, false},
+		{"auto", true, false, true},   // TTY, NO_COLOR unset → on
+		{"auto", false, false, false}, // not a TTY → off
+		{"auto", true, true, false},   // NO_COLOR set → off
+		{"auto", false, true, false},
+		{"", true, false, true}, // empty mode behaves as auto
+	}
+	for _, c := range cases {
+		if got := resolveColor(c.mode, c.isTTY, c.noColor); got != c.want {
+			t.Errorf("resolveColor(%q, isTTY=%v, noColor=%v) = %v, want %v",
+				c.mode, c.isTTY, c.noColor, got, c.want)
+		}
+	}
+}
+
+func TestValidateColor(t *testing.T) {
+	for _, ok := range []string{"auto", "always", "never"} {
+		if err := validateColor(ok); err != nil {
+			t.Errorf("validateColor(%q) = %v, want nil", ok, err)
+		}
+	}
+	if err := validateColor("rainbow"); err == nil {
+		t.Error("validateColor(\"rainbow\") = nil, want error")
+	}
+}
+
+func TestPalette(t *testing.T) {
+	on := palette{enabled: true}
+	if got := on.green("x"); got != ansiGreen+"x"+ansiReset {
+		t.Errorf("green when enabled = %q", got)
+	}
+	// Every colored fragment must be wrapped when enabled.
+	for name, got := range map[string]string{
+		"green":  on.green("x"),
+		"yellow": on.yellow("x"),
+		"path":   on.path("x"),
+		"line":   on.line("x"),
+		"dim":    on.dim("x"),
+	} {
+		if !strings.HasPrefix(got, "\033[") || !strings.HasSuffix(got, ansiReset) {
+			t.Errorf("%s when enabled = %q, want wrapped in ANSI codes", name, got)
+		}
+	}
+
+	off := palette{enabled: false}
+	for name, got := range map[string]string{
+		"green":  off.green("x"),
+		"yellow": off.yellow("x"),
+		"path":   off.path("x"),
+		"line":   off.line("x"),
+		"dim":    off.dim("x"),
+	} {
+		if got != "x" {
+			t.Errorf("%s when disabled = %q, want %q (unchanged)", name, got, "x")
+		}
+	}
+}
+
+func TestFileIsTerminal(t *testing.T) {
+	// /dev/null is a character device, so it reports as a terminal.
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	if !fileIsTerminal(devNull) {
+		t.Errorf("fileIsTerminal(%s) = false, want true (char device)", os.DevNull)
+	}
+	if err := devNull.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// A regular file is not a terminal.
+	regular := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(regular, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, err := os.Open(regular)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if fileIsTerminal(f) {
+		t.Errorf("fileIsTerminal(regular file) = true, want false")
+	}
+	// Stat on a closed file errors → treated as not a terminal.
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if fileIsTerminal(f) {
+		t.Errorf("fileIsTerminal(closed file) = true, want false")
+	}
+}
+
+func TestNewPalette(t *testing.T) {
+	orig := flagColor
+	t.Cleanup(func() { flagColor = orig })
+
+	flagColor = "always"
+	if !newPalette().enabled {
+		t.Error("newPalette() with --color=always should be enabled regardless of TTY")
+	}
+
+	flagColor = "never"
+	if newPalette().enabled {
+		t.Error("newPalette() with --color=never should be disabled")
+	}
+}

--- a/cmd/colref/color_test.go
+++ b/cmd/colref/color_test.go
@@ -76,7 +76,9 @@ func TestPalette(t *testing.T) {
 }
 
 func TestFileIsTerminal(t *testing.T) {
-	// /dev/null is a character device, so it reports as a terminal.
+	// /dev/null is a character device, so it reports as a terminal. This is the
+	// documented, deliberate tradeoff of the ModeCharDevice proxy (see
+	// fileIsTerminal) — output to a dummy device is discarded, so it's harmless.
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
 		t.Fatalf("open %s: %v", os.DevNull, err)

--- a/docs/content/docs/usage/_index.md
+++ b/docs/content/docs/usage/_index.md
@@ -22,6 +22,7 @@ colref check --orm <orm> --model <Model> --field <field> [path]
 | `--model` | Model name to look up (required) |
 | `--field` | Field name to search for (required) |
 | `--format` | Output format: `text` (default), `json` |
+| `--color` | Colorize `text` output: `auto` (default), `always`, `never` |
 
 ## Output formats
 
@@ -57,6 +58,20 @@ colref check --orm django --model User --field email --format json path/to/proje
 - `references` is always an array — `[]` when nothing matches, never `null`.
 - HTML characters are **not** escaped, so source snippets stay readable on the wire — Ruby lambdas (`->`), safe navigation (`&.`), and ERB (`<%= %>`) appear verbatim rather than as `\u003e` / `\u0026`.
 - Errors (unknown model/field/orm/format) are still reported on stderr with a non-zero exit code; they are not emitted as JSON.
+
+## Color
+
+The `text` format is colorized for readability: the heading is green when references are found and yellow when none are, file paths are cyan, and `:line` numbers are dimmed. Matched source text is left uncolored so it stands out against the colored metadata.
+
+Color is controlled by `--color`:
+
+- `auto` (default) — colorize only when stdout is a terminal. When the output is piped or redirected, color is disabled automatically, so `text` output stays clean for downstream tools.
+- `always` — always colorize, even when piped.
+- `never` — never colorize.
+
+The [`NO_COLOR`](https://no-color.org/) environment variable is honored: when it is set to a non-empty value, `auto` disables color. `--color=always` overrides both the TTY check and `NO_COLOR`.
+
+`json` output is never colorized regardless of `--color`.
 
 ## ORM-specific behavior
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -268,6 +268,46 @@ func TestE2E_JSONOutput(t *testing.T) {
 	})
 }
 
+func TestE2E_ColorOutput(t *testing.T) {
+	fixture := "fixtures/django"
+	const esc = "\033[" // start of any ANSI SGR sequence
+
+	t.Run("PipedDefaultHasNoColor", func(t *testing.T) {
+		// CombinedOutput pipes stdout (not a TTY), so --color=auto must emit no
+		// escape codes — text output stays clean for downstream tools.
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, "References found for User.email")
+		assertNotContains(t, out, esc)
+	})
+
+	t.Run("ColorAlwaysEmitsCodes", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "--color", "always", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertContains(t, out, esc)
+	})
+
+	t.Run("ColorNever", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "--color", "never", fixture)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput:\n%s", err, out)
+		}
+		assertNotContains(t, out, esc)
+	})
+
+	t.Run("InvalidColor", func(t *testing.T) {
+		out, err := run(t, "check", "--orm", "django", "--model", "User", "--field", "email", "--color", "rainbow", fixture)
+		if err == nil {
+			t.Fatal("expected non-zero exit for unknown color")
+		}
+		assertContains(t, out, `unknown --color "rainbow"`)
+	})
+}
+
 func TestE2E_Django_ModelsPackage(t *testing.T) {
 	fixture := "fixtures/django-models-pkg"
 


### PR DESCRIPTION
Closes #210

## Summary

Colorizes the human-readable `text` output of `check` for readability, gated by a new `--color` flag. Approach follows the palette style of the sibling project [gomarklint](https://github.com/shinagawa-web/gomarklint) (raw ANSI escapes, no color-library dependency), and adds the TTY / `NO_COLOR` / flag gating that gomarklint does not have.

## What it looks like

- Heading **green** when references are found, **yellow** when none
- File paths **cyan**, `:line` numbers **dimmed** (gray)
- Matched source text **left uncolored** — a deliberate choice: it follows gomarklint's convention of never coloring primary content, and keeps the matched code the visually dominant element against the colored metadata. (The issue lists "matched text in a third color"; I opted for uncolored instead — happy to color it if preferred.)

## Behavior (`--color auto|always|never`, default `auto`)

- `auto` — color only when stdout is a TTY **and** `NO_COLOR` is unset/empty. Piped or redirected output is plain, so scripts and `| jq`-style pipelines are unaffected.
- `always` — always color, overriding both the TTY check and `NO_COLOR`.
- `never` — never color.
- Invalid values are rejected with a clear error and non-zero exit.
- `json` output is never colorized.

## Correctness notes

- **Alignment:** column width and padding are computed on the *plain* `file:line` label, so ANSI escape bytes never throw off alignment. Verified that stripping ANSI from `--color=always` output reproduces the plain layout byte-for-byte.
- **No dependency:** TTY detection uses `os.Stdout.Stat()` + `ModeCharDevice`; the decision lives in a pure `resolveColor(mode, isTTY, noColor)` for full testability.
- **.gitignore fix:** anchored the `colref` pattern to `/colref`. The unanchored pattern matched the `cmd/colref/` source directory and silently ignored the new `color.go` (already-tracked files were unaffected, so this was latent).

## Tests

- Unit: `resolveColor` table, `validateColor`, palette enabled/disabled, `fileIsTerminal` (char-device / regular-file / closed-file), colored `runScan`/`printRefs` via `--color=always`.
- e2e: piped default emits no escapes, `--color always` emits escapes, `--color never` plain, invalid value rejected.
- Coverage 100%, `go vet` clean, all unit + e2e pass.

## Note on CI

This branch is cut from `main` (pre-#216), so its golangci workflow is still the reviewdog one. The official-action switch and the `.golangci.yml` v2-schema fix land in #216.