### PR TITLE
ci: compute coverage gate from profile, not 'go tool cover -func' total

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check-coverage: ## Run tests with coverage and enforce minimum threshold
 	@coverage_file=$$(mktemp); \
 	trap 'rm -f "$$coverage_file"' EXIT; \
 	$(GOTEST) $$(go list ./... | grep -v /e2e) -coverprofile="$$coverage_file"; \
-	total=$$($(GOCMD) tool cover -func="$$coverage_file" | grep '^total' | awk '{print $$3}' | tr -d '%'); \
+	total=$$(awk 'NR>1 { tot+=$$2; if ($$3>0) cov+=$$2 } END { if (tot>0) printf "%.1f", 100*cov/tot; else print "0.0" }' "$$coverage_file"); \
 	echo "Total coverage: $${total}%"; \
 	if ! awk "BEGIN { exit !($$total >= $(COVERAGE_THRESHOLD)) }"; then \
 		echo "FAIL: coverage $${total}% is below threshold $(COVERAGE_THRESHOLD)%"; exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ update-golden: build-e2e ## Regenerate golden files for pattern battery tests
 
 check-coverage: ## Run tests with coverage and enforce minimum threshold
 	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
-	@coverage_file=$$(mktemp); \
+	@set -e; \
+	coverage_file=$$(mktemp); \
 	trap 'rm -f "$$coverage_file"' EXIT; \
 	$(GOTEST) $$(go list ./... | grep -v /e2e) -coverprofile="$$coverage_file"; \
 	total=$$(awk 'NR>1 { tot+=$$2; if ($$3>0) cov+=$$2 } END { if (tot>0) printf "%.1f", 100*cov/tot; else print "0.0" }' "$$coverage_file"); \

--- a/cmd/colref/check_test.go
+++ b/cmd/colref/check_test.go
@@ -790,8 +790,12 @@ func TestCheckCmd_RunE_InvalidFormat(t *testing.T) {
 		"--orm", "django",
 		"--format", "xml",
 	})
-	if err := rootCmd.Execute(); err == nil {
+	err := rootCmd.Execute()
+	if err == nil {
 		t.Fatal("expected error for invalid --format")
+	}
+	if !strings.Contains(err.Error(), `unknown --format "xml"`) {
+		t.Fatalf("error is not the --format validation failure: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #218

## Problem

`make check-coverage` derives the enforced total from `go tool cover -func <profile> | grep ^total`. That total under-counts uncovered blocks inside **function literals** (e.g. the cobra `RunE:` closure, `main.go` closures), so it reports a higher percentage than the real statement coverage.

On a deliberately gappy `cmd/colref` profile:

| Metric | Value |
|---|---|
| `go test -cover` (truth) | **97.3%** |
| `go tool cover -func` total (old gate) | 98.3% |
| profile-direct `covered_stmts / total_stmts` (new gate) | **97.3%** |

Because the gate read the lenient number, a func-literal gap could pass the 100% threshold unnoticed — which is exactly how the `RunE` `validateFormat` error branch stayed uncovered on `main` (real coverage was 99.9%, gate said 100%).

## Fix

- Compute the total directly from the coverage profile (executed statement counts / total statement counts), matching `go test -cover`. Guards an empty profile as `0.0`. Threshold stays 100%.
- The honest metric immediately exposed the pre-existing uncovered `validateFormat` `RunE` branch, so add `TestCheckCmd_RunE_InvalidFormat` to close it and keep the gate green at a real 100%.

## Verification

- `make check-coverage` → `Total coverage: 100.0%` / `Coverage OK.`
- Empty profile → `0.0` (no divide-by-zero)
- `golangci-lint` 0 issues, `go vet` clean, unit + e2e pass

## Relationship to other PRs

- Independent of #217 (color). #217 already adds `TestCheckCmd_RunE_InvalidFormat` **and** `_InvalidColor` on its own branch; whichever merges second will need a trivial rebase to drop the duplicate `_InvalidFormat` test. Flagging so it is expected.